### PR TITLE
Add tag version 1.0.1 on dmcloud requirements

### DIFF
--- a/requirements/dm-xblock.txt
+++ b/requirements/dm-xblock.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/openfun/dmcloud.git@1.0.0#egg=dmcloud-xblock
+-e git+https://github.com/openfun/dmcloud.git@1.0.1#egg=dmcloud-xblock
 -e git+https://github.com/dailymotion/cloudkey-py@1.2.7#egg=cloudkey


### PR DESCRIPTION
Fix bug describes here : https://fun.plan.io/issues/882
Improve player adding multiple download : https://fun.plan.io/issues/779#change-3263
