### PR TITLE
Use the openfun cloudkey-py fork

### DIFF
--- a/requirements/dm-xblock.txt
+++ b/requirements/dm-xblock.txt
@@ -1,2 +1,2 @@
 -e git+https://github.com/openfun/dmcloud.git@1.1.4#egg=dmcloud-xblock
--e git+https://github.com/dailymotion/cloudkey-py@1.2.7#egg=cloudkey
+-e git+https://github.com/openfun/cloudkey-py@1.2.7-1#egg=cloudkey


### PR DESCRIPTION
This is necessary to integrate a pull request that allows us to install
cloudkey-key with no github ssh key:
https://github.com/openfun/cloudkey-py/pull/1