### PR TITLE
Include inactive users in enrollment stats

### DIFF
--- a/course_dashboard/stats.py
+++ b/course_dashboard/stats.py
@@ -73,7 +73,10 @@ def population_by_country(course_key_string=None):
     return course_population
 
 def active_enrollments(course_key=None):
-    queryset = CourseEnrollment.objects.filter(user__is_active=True)
+    """
+    Return a queryset of active course enrollments.
+    """
+    queryset = CourseEnrollment.objects.filter(is_active=True)
     if course_key is not None:
         queryset = queryset.filter(course_id=course_key)
     return queryset

--- a/course_dashboard/tests/base.py
+++ b/course_dashboard/tests/base.py
@@ -2,19 +2,21 @@ import csv
 from StringIO import StringIO
 
 from django.core.urlresolvers import reverse
-from django.test import TestCase
 from django.test.utils import override_settings
 
 from courseware.tests.factories import InstructorFactory
 from student.tests.factories import CourseEnrollmentFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.django_utils import TEST_DATA_MOCK_MODULESTORE
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
-class BaseCourseDashboardTestCase(TestCase):
+class BaseCourseDashboardTestCase(ModuleStoreTestCase):
 
     def setUp(self):
+        super(BaseCourseDashboardTestCase, self).setUp(create_user=False)
+
         self.course = CourseFactory.create()
         instructor = InstructorFactory.create(course_key=self.course.id)
         self.client.login(username=instructor.username, password="test")

--- a/course_dashboard/tests/test_global_views.py
+++ b/course_dashboard/tests/test_global_views.py
@@ -26,7 +26,7 @@ class GlobalViewsTestCase(ModuleStoreTestCase):
         response = self.client.get(url)
         self.assertEqual(200, response.status_code)
 
-    def test_non_staff_is_not_allowed(self):
+    def test_logged_out_user_is_not_allowed(self):
         self.client.logout()
         url = reverse('course-dashboard-global:home')
         response = self.client.get(url)

--- a/course_dashboard/tests/test_views.py
+++ b/course_dashboard/tests/test_views.py
@@ -1,14 +1,17 @@
 from datetime import datetime
 
+from django.test.utils import override_settings
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 from student.tests.factories import UserFactory
+from xmodule.modulestore.tests.django_utils import TEST_DATA_MOCK_MODULESTORE
 
 from course_dashboard import views
 from .base import BaseCourseDashboardTestCase
 
 
+@override_settings(MODULESTORE=TEST_DATA_MOCK_MODULESTORE)
 class EnrollmentStatsTestCase(BaseCourseDashboardTestCase):
 
     def get_course_enrollment_stats(self, course, response_format=None):


### PR DESCRIPTION
Inactive users should be listed, but not inactive enrollments.
Also, fix course_dashboard tests.