### PR TITLE
Fix most active forum user in course dashboard

### DIFF
--- a/course_dashboard/stats.py
+++ b/course_dashboard/stats.py
@@ -139,13 +139,8 @@ def most_active_username(threads):
     user_activity = defaultdict(int)
     for thread in threads:
         user_activity[thread["username"]] += 1
-    best_username = None
-    max_thread_count = 0
-    for username, thread_count in user_activity.iteritems():
-        if thread_count > max_thread_count:
-            max_thread_count = thread_count
-        best_username = username
-    return best_username
+    # user_activity is of the form {"username": count, ...}
+    return max(user_activity.items(), key=lambda i: i[1])[0]
 
 class EnrollmentStats(object):
     """Provide enrollments stats for a given course."""

--- a/course_dashboard/tests/test_stats.py
+++ b/course_dashboard/tests/test_stats.py
@@ -66,3 +66,12 @@ class StatsTestCase(BaseCourseDashboardTestCase):
         }]
         threads_per_day = stats.forum_threads_per_day(threads)
         self.assertEqual([(datetime(year=2015, month=2, day=3), 1)], threads_per_day)
+
+    def test_most_active_username(self):
+        threads = [
+            {"username": 1},
+            {"username": 1},
+            {"username": 2},
+        ]
+        self.assertEqual(1, stats.most_active_username(threads))
+


### PR DESCRIPTION
Most active user was not the most active, but the last one.
This closes issue #1316.