### PR TITLE
Fix featured article in newsfeed preview

### DIFF
--- a/newsfeed/templates/newsfeed/article/list.html
+++ b/newsfeed/templates/newsfeed/article/list.html
@@ -8,30 +8,30 @@
 
 <section class="container">
     <section class="featured-articles">
-        % if articles:
-            % if featured_section and featured_section.image:
+        % if featured_section and featured_section.image:
             % if featured_section.article:
-            <a href="${article_url(featured_section.article)}">
-            % endif
-                <section class="top-article" style="${background_style(featured_section.image.url)}">
-                    <section class="article-preview">
-                        <section class="article-title">
-                            % if featured_section.title:
-                            <h2>${featured_section.title}</h2>
-                            % elif featured_section.article:
-                            <h2>${featured_section.article.title}</h2>
-                            % else:
-                            <h2>${_("News Section")}</h2>
-                            % endif
+                <a href="${article_url(featured_section.article)}">
+                % endif
+                    <section class="top-article" style="${background_style(featured_section.image.url)}">
+                        <section class="article-preview">
+                            <section class="article-title">
+                                % if featured_section.title:
+                                <h2>${featured_section.title}</h2>
+                                % elif featured_section.article:
+                                <h2>${featured_section.article.title}</h2>
+                                % else:
+                                <h2>${_("News Section")}</h2>
+                                % endif
 
+                            </section>
                         </section>
                     </section>
-                </section>
-            % if featured_section.article:
-            </a>
+                % if featured_section.article:
+                </a>
             % endif
-            % endif
+        % endif
 
+        % if articles:
             % for article in articles[:3]:
             <section class="featured-article">
                 <a href="${article_url(article)}">

--- a/newsfeed/tests/factories.py
+++ b/newsfeed/tests/factories.py
@@ -13,3 +13,10 @@ class ArticleFactory(factory.DjangoModelFactory):
     slug = factory.Sequence(lambda n: 'a-great-slug-{0}'.format(n))
     text = u"J'étais un texte accentué !"
     created_at = factory.lazy_attribute(lambda x: datetime.datetime.now())
+
+
+class FeaturedSectionFactory(factory.DjangoModelFactory):
+    FACTORY_FOR = models.FeaturedSection
+
+    title = u"Featured section from outer space"
+    image = factory.django.ImageField()

--- a/newsfeed/tests/test_views.py
+++ b/newsfeed/tests/test_views.py
@@ -6,16 +6,18 @@ from django.core.urlresolvers import reverse
 
 from student.tests.factories import UserFactory
 
-from newsfeed.models import Article
-
-from .factories import ArticleFactory
+from . import factories
 
 
 class ViewArticlesTest(TestCase):
 
+    def create_user_and_login(self, as_staff=False):
+        user = UserFactory(is_staff=as_staff)
+        self.client.login(username=user.username, password='test')
+
     def test_article_list(self):
-        published_article = ArticleFactory.create(published=True)
-        unpublished_article = ArticleFactory.create(title="Work in progress", slug="work-in-progress",
+        published_article = factories.ArticleFactory.create(published=True)
+        unpublished_article = factories.ArticleFactory.create(title="Work in progress", slug="work-in-progress",
                 published=False)
 
         url = reverse("newsfeed-landing")
@@ -25,7 +27,7 @@ class ViewArticlesTest(TestCase):
         self.assertNotIn(str(unpublished_article.title), response.content)
 
     def test_article_details(self):
-        article = ArticleFactory.create(title="great title", published=True)
+        article = factories.ArticleFactory.create(title="great title", published=True)
 
         url = reverse("newsfeed-article", kwargs={"slug": article.slug})
         response = self.client.get(url)
@@ -33,28 +35,30 @@ class ViewArticlesTest(TestCase):
         self.assertIn(str(article.title), response.content)
 
     def test_preview_without_rights(self):
-        user = UserFactory(is_staff=False)
-        self.client.login(username=user.username, password='test')
-
+        self.create_user_and_login(False)
         self.preview_article(404)
 
     def test_preview_with_rights(self):
-        user = UserFactory(is_staff=True)
-        self.client.login(username=user.username, password='test')
-
+        self.create_user_and_login(True)
         self.preview_article(200)
 
     def preview_article(self, expected_status_code):
-        article = ArticleFactory.create(published=False)
+        article = factories.ArticleFactory.create(published=False)
         url = reverse('newsfeed-article-preview', kwargs={'slug': article.slug})
         response = self.client.get(url)
         self.assertEqual(expected_status_code, response.status_code)
 
     def test_preview_landing(self):
-        article = ArticleFactory.create(published=False)
+        self.create_user_and_login(True)
+        article = factories.ArticleFactory.create(published=False)
+        featured_section = factories.FeaturedSectionFactory.create(article=article)
         url = reverse('newsfeed-landing-preview', kwargs={'slug': article.slug})
         response = self.client.get(url)
-        self.assertTrue(article.slug in response.content)
+
+        self.assertTrue(str(article.slug) in response.content)
+        self.assertTrue("\"top-article\"" in response.content)
+        self.assertTrue(str(featured_section.title) in response.content)
+        self.assertFalse("\"featured-article\"" in response.content)
 
     def test_admin_upload_url(self):
         upload_url = reverse('news-ckeditor-upload')

--- a/newsfeed/views.py
+++ b/newsfeed/views.py
@@ -26,17 +26,20 @@ class ArticleListView(mako.MakoTemplateMixin, ListView):
         # Display all published articles. We might want to filter on language
         # and limit the queryset to the first n results in the future (see the
         # .featured() method).
-        queryset = models.Article.objects.viewable()
+        queryset = self.get_viewable_queryset()
         # We exclude the article that's selected in the featured section.
         featured_section = models.FeaturedSection.get_solo()
         if featured_section and featured_section.article:
             queryset = queryset.exclude(id=featured_section.article.id)
         return queryset
+
+    def get_viewable_queryset(self):
+        return models.Article.objects.viewable()
 article_list = ArticleListView.as_view()
 
 
 class ArticleListPreviewView(StaffOnlyView, ArticleListView):
-    def get_queryset(self):
+    def get_viewable_queryset(self):
         return models.Article.objects.published_or(slug=self.kwargs['slug'])
 article_list_preview = ArticleListPreviewView.as_view()
 


### PR DESCRIPTION
Previously, featured section was displayed twice in newsfeed preview:
once in the top-article section, and once in the featured articles
section.