### PR TITLE
Fix django_debug_toolbar circular import

### DIFF
--- a/fun/cms/urls.py
+++ b/fun/cms/urls.py
@@ -8,8 +8,6 @@ from django.conf.urls import url, include, patterns
 from cms.urls import handler404, handler500
 
 urlpatterns = patterns( '',
-
-    (r'^selftest/', include('selftest.urls')),
-
     (r'^', include('cms.urls')),
+    (r'^', include('fun.common_urls')),
 )

--- a/fun/common_urls.py
+++ b/fun/common_urls.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+from django.conf.urls import url, include, patterns
+
+
+urlpatterns = patterns('',
+    (r'^selftest/', include('selftest.urls')),
+)
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns += patterns('',
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    )

--- a/fun/envs/dev.py
+++ b/fun/envs/dev.py
@@ -37,7 +37,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 ################################ DEBUG TOOLBAR ################################
 
-DEBUG_TOOLBAR_INSTALLED_APPS = ('debug_toolbar', 'django_extensions',)
+DEBUG_TOOLBAR_INSTALLED_APPS = ('debug_toolbar', 'djpyfs',)
 DEBUG_TOOLBAR_MIDDLEWARE_CLASSES = (
     'django_comment_client.utils.QueryCountDebugMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
@@ -51,18 +51,19 @@ DEBUG_TOOLBAR_PANELS = [
     'debug_toolbar.panels.headers.HeadersPanel',
     'debug_toolbar.panels.request.RequestPanel',
     'debug_toolbar.panels.sql.SQLPanel',
-    'debug_toolbar.panels.staticfiles.StaticFilesPanel',
-    'debug_toolbar.panels.templates.TemplatesPanel',
-    'debug_toolbar.panels.cache.CachePanel',
     'debug_toolbar.panels.signals.SignalsPanel',
     'debug_toolbar.panels.logging.LoggingPanel',
-    'debug_toolbar.panels.redirects.RedirectsPanel',
+    'debug_toolbar.panels.profiling.ProfilingPanel',
 ]
 
 DEBUG_TOOLBAR_CONFIG = {
     'INTERCEPT_REDIRECTS': False,
-#    'SHOW_TOOLBAR_CALLBACK': lambda _: True,
+    'SHOW_TOOLBAR_CALLBACK': "{}.true".format(__name__)
 }
+def true(request):
+    return True
+
+DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
 ########################### PIPELINE #################################
 

--- a/fun/envs/lms/common.py
+++ b/fun/envs/lms/common.py
@@ -71,11 +71,11 @@ INSTALLED_APPS += (
     'backoffice',
     )
 
-# replace edX's StaticCountentServer middleware by ours (which generate nice thumbnails)
+# replace edX's StaticContentServer middleware by ours (which generates nice thumbnails)
 MIDDLEWARE_CLASSES = list(MIDDLEWARE_CLASSES)
-position = MIDDLEWARE_CLASSES.index('contentserver.middleware.StaticContentServer')
-MIDDLEWARE_CLASSES.remove('contentserver.middleware.StaticContentServer')
-MIDDLEWARE_CLASSES.insert(position, 'fun.middleware.ThumbnailStaticContentServer')
+MIDDLEWARE_CLASSES[
+    MIDDLEWARE_CLASSES.index('contentserver.middleware.StaticContentServer')
+] = 'fun.middleware.ThumbnailStaticContentServer'
 
 TEMPLATE_CONTEXT_PROCESSORS += ('fun.context_processor.fun_settings',)
 

--- a/fun/lms/urls.py
+++ b/fun/lms/urls.py
@@ -31,12 +31,12 @@ urlpatterns = patterns('',
     ),
     url(r'^courses/fun/dashboard/', include('course_dashboard.urls_global', namespace='course-dashboard-global')),
 
-    (r'^selftest/', include('selftest.urls')),
-
     # Grade downloads
     url(r'^courses/{}/instructor/api/'.format(settings.COURSE_ID_PATTERN), include('fun_instructor.urls')),
     url(r'^get-grades/{}/(?P<filename>.+.csv)'.format(settings.COURSE_ID_PATTERN), 'fun_instructor.views.get_grades'),
+
     (r'^', include('lms.urls')),
+    (r'^', include('fun.common_urls')),
 )
 
 # Ckeditor - Used by Univerity app
@@ -47,4 +47,3 @@ urlpatterns += (
 if settings.DEBUG:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-


### PR DESCRIPTION
According to
https://django-debug-toolbar.readthedocs.org/en/1.3/installation.html#explicit-setup,
django_debug_toolbar frequently causes circular import errors in debug
mode. To avoid that we do an explicit configuration.

Also:
- use the same panels as edX
- create common_urls.py for urls that are supposed to be both in lms and
  cms.