### PR TITLE
Accelerate backoffice course listing

### DIFF
--- a/backoffice/templatetags/course.py
+++ b/backoffice/templatetags/course.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
 
 from django import template
-from django.template.defaultfilters import stringfilter
 
-from courseware.courses import course_image_url, get_course_about_section
+from courseware.courses import course_image_url
+from courses.utils import get_about_section
 
 register = template.Library()
 
-ABOUT_SECTION_FIELDS = ['title', 'university']
 
 @register.assignment_tag
 def course_infos(course):
-    d = {}
-    for section in ABOUT_SECTION_FIELDS:
-        d[section] = get_course_about_section(course, section)
-    d['course_image_url'] = course_image_url(course)
+    d = {
+        'course_image_url': course_image_url(course)
+    }
+    for section in ['title', 'university']:
+        d[section] = get_about_section(course, section)
     return d

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -1,0 +1,13 @@
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.exceptions import ItemNotFoundError
+
+def get_about_section(course_descriptor, field):
+    """
+    Faster alternative to courseware.courses.get_course_about_section.
+    Returns None if the key does not exist.
+    """
+    usage_key = course_descriptor.id.make_usage_key("about", field)
+    try:
+        return modulestore().get_item(usage_key).data
+    except ItemNotFoundError:
+        return None


### PR DESCRIPTION
The course list is displayed faster because there are no calls made to
get_course_about_section and to get_request_for_thread.

This closes issue #1413.