### PR TITLE
Issue1435 Anonymize usernames in answer distribution reports.

### DIFF
--- a/course_dashboard/reports_manager/tasks.py
+++ b/course_dashboard/reports_manager/tasks.py
@@ -1,16 +1,15 @@
-import codecs
 import csv
 import json
 from time import time
 
-from django.contrib.auth.models import User
+from django.conf import settings
 
 from courseware.models import StudentModule
 from student.models import UserProfile
 from instructor_task.tasks_helper import TaskProgress
 from xmodule.modulestore.django import modulestore
 
-from course_dashboard.reports_manager.utils import ANSWERS_DISTRIBUTION_REPORTS_DIRECTORY
+from course_dashboard.reports_manager.utils import ANSWERS_DISTRIBUTION_REPORTS_DIRECTORY, anonymize_username
 from course_dashboard.problem_stats.utils import fetch_problem, fetch_ancestors_names, get_problem_size
 from fun import shared
 
@@ -48,7 +47,7 @@ def fetch_user_profile_data(student_module):
     """
     user = student_module.student
     user_profile = UserProfile.objects.get(user=user)
-    data_row = [unicode(user.id),
+    data_row = [anonymize_username(user.username),
                 unicode(user_profile.gender),
                 unicode(user_profile.year_of_birth),
                 unicode(user_profile.level_of_education)]

--- a/course_dashboard/reports_manager/tests/test_tasks.py
+++ b/course_dashboard/reports_manager/tests/test_tasks.py
@@ -1,7 +1,8 @@
-import os
-import json
-import shutil
 import csv
+
+import json
+import os
+import shutil
 
 from mock import patch
 from django.conf import settings
@@ -15,7 +16,7 @@ from instructor_task.tests.test_tasks import PROBLEM_URL_NAME
 
 from course_dashboard.problem_stats.tests.test_problem_monitor import ProblemMonitorTestCase
 from course_dashboard.reports_manager.tasks import generate_answers_distribution_report, get_path
-from course_dashboard.reports_manager.utils import build_answers_distribution_report_name
+from course_dashboard.reports_manager.utils import build_answers_distribution_report_name, anonymize_username
 
 @override_settings(SHARED_ROOT='/tmp/shared-test-answers-distribution')
 class AnswersDistributionReportsTask(InstructorTaskModuleTestCase, ProblemMonitorTestCase):
@@ -59,9 +60,9 @@ class AnswersDistributionReportsTask(InstructorTaskModuleTestCase, ProblemMonito
 
     def _create_response_row(self):
         user_profile = UserProfile.objects.get(user__username=self.username)
-        response_row = [unicode(x) for x in
-                        [user_profile.user.id, user_profile.gender, user_profile.year_of_birth,
-                         user_profile.level_of_education]] + [OPTION_1, OPTION_2]
+        response_row = [unicode(x) for x in [anonymize_username(user_profile.user.username),
+                                             user_profile.gender, user_profile.year_of_birth,
+                                             user_profile.level_of_education]] + [OPTION_1, OPTION_2]
         return response_row
 
     def test_generate_answers_distribution_report(self):

--- a/course_dashboard/reports_manager/utils.py
+++ b/course_dashboard/reports_manager/utils.py
@@ -1,4 +1,6 @@
 import datetime
+import hashlib
+import hmac
 import os
 import unicodedata
 
@@ -24,7 +26,6 @@ def get_reports_from_course(course_key):
 
 def remove_accents(input_str):
     """Replace accented caracter by unaccented caracters"""
-    
     nfkd_form = unicodedata.normalize('NFKD', input_str)
     only_ascii = nfkd_form.encode('ASCII', 'ignore')
     return only_ascii
@@ -42,10 +43,16 @@ def build_answers_distribution_report_name(problem):
     Returns:
         The answer distribution report name (Unicode).
     """
-
     running_report_name = course_and_time_based_filename_generator(problem.location,
                                                                    problem.display_name)
     running_report_name += u".csv"
     return running_report_name[:255]
 
-
+def anonymize_username(username):
+    """ Anonymize username.
+    Args:
+        username (unicode)
+    Returns:
+        (str) A 64-bit hash.
+    """
+    return hmac.new(settings.ANONYMIZATION_KEY, username, hashlib.sha256).hexdigest()

--- a/fun/envs/common.py
+++ b/fun/envs/common.py
@@ -220,3 +220,5 @@ CACHES = {
         "LOCATION": ORA2_FILEUPLOAD_CACHE_ROOT
     }
 }
+
+ANONYMIZATION_KEY = """dummykey"""


### PR DESCRIPTION
Using the private key defined in settings.
Ticket https://fun.plan.io/issues/1435.