### PR TITLE
Rewrite /fonts urls in debug mode

### DIFF
--- a/fun/common_urls.py
+++ b/fun/common_urls.py
@@ -8,6 +8,13 @@ urlpatterns = patterns('',
 
 if settings.DEBUG:
     import debug_toolbar
-    urlpatterns += patterns('',
+    urlpatterns += patterns(
+        '',
         url(r'^__debug__/', include(debug_toolbar.urls)),
+
+        # Fonts are loaded from /fonts/ in DEBUG mode because the loaded
+        # stylesheets are not compiled/compressed.
+        url(r'^(?P<path>fonts/vendor/.+)$',
+            view='django.views.static.serve',
+            kwargs={'document_root' : settings.STATIC_ROOT}),
     )


### PR DESCRIPTION
This is the only way to load FontAwesome from non-compiled/compressed
stylesheets.

This closes issue #1107.

The long explanation is here: https://fun.plan.io/issues/1107