### PR TITLE
In the course dashboard, French territories count as French

### DIFF
--- a/course_dashboard/stats.py
+++ b/course_dashboard/stats.py
@@ -11,6 +11,8 @@ import lms.lib.comment_client as comment_client
 from student.models import CourseEnrollment
 from student.models import User
 
+import fun.utils.countries
+
 
 def enrollments_per_day(course_key_string=None, since=None):
     """
@@ -67,10 +69,10 @@ def population_by_country(course_key_string=None):
         .filter(population__gt=0)
         .order_by(country_field)
     )
-    course_population = {}
+    course_population = defaultdict(int)
     for result in query:
-        country = result[country_field]
-        course_population[country] = result["population"]
+        country = fun.utils.countries.territory_country(result[country_field])
+        course_population[country] += result["population"]
     return course_population
 
 def active_enrollments(course_key=None):

--- a/course_dashboard/tests/test_stats.py
+++ b/course_dashboard/tests/test_stats.py
@@ -37,6 +37,13 @@ class StatsTestCase(BaseCourseDashboardTestCase):
         self.assertEqual({}, empty_course_population)
         self.assertEqual({'FR': 1}, course_population)
 
+    def test_dependent_territories_are_not_listed_separately(self):
+        course = CourseFactory.create()
+        self.enroll_student(course, user__profile__country='GF', user__is_active=False)
+        self.enroll_student(course, user__profile__country='PF', user__is_active=False)
+        course_population = stats.population_by_country(self.get_course_id(course))
+        self.assertEqual({'FR': 2}, course_population)
+
     def test_inactive_students_are_included_but_not_inactive_enrollments(self):
         course = CourseFactory.create()
         self.enroll_student(course, user__profile__country='FR', user__is_active=False)

--- a/fun/utils/countries.py
+++ b/fun/utils/countries.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+# Dictionary of (territory code, country code) that associates a territory to
+# its administering country.
+# This is to address an over-exhaustive country list in django_countries.data.
+TERRITORIES = {
+    'BL': 'FR',# Saint Barthélemy
+    'GF': 'FR',# French Guiana
+    'GP': 'FR',# Guadeloupe
+    'MF': 'FR',# Saint Martin (French part)
+    'MQ': 'FR',# Martinique
+    'NC': 'FR',# New Caledonia"
+    'PF': 'FR',# French Polynesia"
+    'PM': 'FR',# Saint Pierre and Miquelon
+    'RE': 'FR',# Réunion
+    'TF': 'FR',# French Southern Territories
+    'WF': 'FR',# Wallis and Futuna
+    'YT': 'FR',# Mayotte
+}
+
+def territory_country(territory_code):
+    """Return the country associated to a territory code."""
+    return TERRITORIES.get(territory_code, territory_code)


### PR DESCRIPTION
We add the 11 territories listed here:
http://en.wikipedia.org/wiki/Overseas_departments_and_territories_of_France
as well as the French Southern Territories. (Too bad, we won't see the
stats for users coming from Antartica.)

This closes issue #1338.