### PR TITLE
Add tests on dailymotion public id handlers.

### DIFF
--- a/fun/cms/utils.py
+++ b/fun/cms/utils.py
@@ -1,0 +1,7 @@
+from unittest import skipUnless
+
+from django.conf import settings
+
+def skipUnlessCms(func):
+    skipUnless(settings.ROOT_URLCONF == 'fun.cms.urls', 'Test only valid in cms')(func)
+    return func

--- a/fun/envs/cms/test.py
+++ b/fun/envs/cms/test.py
@@ -1,0 +1,84 @@
+from .dev import *
+
+ENVIRONMENT = 'test'
+
+############# Disable useless logging
+import logging
+logging.getLogger("audit").setLevel(logging.WARN)
+logging.getLogger("django_comment_client.utils").setLevel(logging.WARN)
+logging.getLogger('edx.celery.task').setLevel(logging.ERROR)
+logging.getLogger("factory").setLevel(logging.WARN)
+logging.getLogger('instructor_task.api_helper').setLevel(logging.ERROR)
+logging.getLogger('instructor_task.tasks_helper').setLevel(logging.ERROR)
+logging.getLogger("raven.contrib.django.client.DjangoClient").setLevel(logging.WARN)
+logging.getLogger('util.models').setLevel(logging.CRITICAL)
+logging.getLogger('xmodule.modulestore.django').setLevel(logging.ERROR)
+
+########### Imported from edx-platform/lms/envs/test.py
+from path import path
+
+SOUTH_TESTS_MIGRATE = False  # To disable migrations and use syncdb instead
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+NOSE_ARGS = [
+    '--id-file', REPO_ROOT / '.testids' / 'lms' / 'noseids',
+    '--xunit-file', REPO_ROOT / 'reports' / 'lms' / 'nosetests.xml',
+    '--nologcapture',
+]
+TEST_ROOT = path("test_root")
+COMMON_TEST_DATA_ROOT = COMMON_ROOT / "test" / "data"
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': TEST_ROOT / 'db' / 'fun.db'
+    },
+
+}
+
+################# mongodb
+MONGO_PORT_NUM = int(os.environ.get('EDXAPP_TEST_MONGO_PORT', '27017'))
+MONGO_HOST = os.environ.get('EDXAPP_TEST_MONGO_HOST', 'localhost')
+CONTENTSTORE = {
+    'ENGINE': 'xmodule.contentstore.mongo.MongoContentStore',
+    'DOC_STORE_CONFIG': {
+        'host': MONGO_HOST,
+        'db': 'xcontent',
+        'port': MONGO_PORT_NUM,
+    }
+}
+
+PASSWORD_HASHERS = (
+    'django.contrib.auth.hashers.SHA1PasswordHasher',
+    'django.contrib.auth.hashers.MD5PasswordHasher',
+)
+STATICFILES_STORAGE='pipeline.storage.NonPackagingPipelineStorage'
+PIPELINE_ENABLED=False
+
+CACHES.update({
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'edx_loc_mem_cache',
+        'KEY_FUNCTION': 'util.memcache.safe_key',
+    },
+
+    'general': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+        'KEY_PREFIX': 'general',
+        'VERSION': 4,
+        'KEY_FUNCTION': 'util.memcache.safe_key',
+    },
+
+    'mongo_metadata_inheritance': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': os.path.join(tempfile.gettempdir(), 'mongo_metadata_inheritance'),
+        'TIMEOUT': 300,
+        'KEY_FUNCTION': 'util.memcache.safe_key',
+    },
+    'loc_cache': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'edx_location_mem_cache',
+    },
+
+})
+################ Disable Django debug toolbar
+INSTALLED_APPS = tuple([app for app in INSTALLED_APPS if app not in DEBUG_TOOLBAR_INSTALLED_APPS])
+MIDDLEWARE_CLASSES = tuple([m for m in MIDDLEWARE_CLASSES if m not in DEBUG_TOOLBAR_MIDDLEWARE_CLASSES])

--- a/fun/tests/test_utils.py
+++ b/fun/tests/test_utils.py
@@ -1,7 +1,17 @@
 # -*- coding: utf-8 -*-
-from django.test import TestCase
-import fun.utils.html
+import json
 
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+from courseware.tests.factories import InstructorFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+from courses.utils import get_about_section
+from courses.views import get_dmcloud_url
+import fun.utils.html
+from fun.cms.utils import skipUnlessCms
 
 class ParagraphText(TestCase):
 
@@ -19,3 +29,32 @@ class ParagraphText(TestCase):
         self.assertEqual("12345", fun.utils.html.truncate_first_paragraph("<p>12345</p>", 5))
         self.assertEqual("...", fun.utils.html.truncate_first_paragraph("<p>12345</p>", 2))
         self.assertEqual("1...", fun.utils.html.truncate_first_paragraph("<p>12345</p>", 4))
+
+@skipUnlessCms
+class TestDmCloudVideoId(ModuleStoreTestCase):
+    def test_dmcloud_public_id(self):
+        """
+        Tests that we always get a correct dailmotion id from the about section.
+        The public video id is store in Mongo surrounded by an iframe tag referencing youtube.
+        As we use dailmotion we need to extract the id from the iframe and create a
+        new one referencing dailymotion (see function get_dmcloud_url).
+        """
+        from contentstore.views.course import settings_handler
+
+        course = CourseFactory.create()
+        instructor = InstructorFactory.create(course_key=course.id)
+        self.client.login(username=instructor.username, password="test")
+
+        DM_CODE = 'x2an9mg'
+        course_details = {'intro_video' : DM_CODE}
+        self.client.post(reverse(settings_handler,
+                                 args=[str(course.id)]),
+                         json.dumps(course_details),
+                         content_type='application/json',
+                         HTTP_ACCEPT='application/json')
+        video_tag_youtube = get_about_section(course, 'video')
+        self.assertIn(DM_CODE, video_tag_youtube)
+        video_tag_dailymotion = '<iframe width="560" height="315" frameborder="0" scrolling="no" allowfullscreen="" src="//www.dailymotion.com/embed/video/' + DM_CODE + '"></iframe>'
+        self.assertEqual(video_tag_dailymotion, get_dmcloud_url(course, video_tag_youtube))
+
+


### PR DESCRIPTION
Teste la gestion des ids des vidéos publiques dailymotion (les teasers dans course_about).
Note : 
 * nouveau décorateur pour  gérer des tests concernant le CMS. (skipUnlessCms)
 * nouveau fichier  fun/envs/cms/test.py  contenant les settings permettant de faire tourner les tests côté cms. Pas de différences avec fun/envs/lms/test.py sauf que ```from .dev import * ``` se rapporte aux settings de dev du cms. Il faut trouver un moyen de faire tourner les tests du cms sans avoir à dupliquer ce fichier.

