### PR TITLE
Override templates: Renaming options and methods

### DIFF
--- a/fun/management/commands/override-templates.py
+++ b/fun/management/commands/override-templates.py
@@ -94,7 +94,7 @@ this script, make sure your openfun/fork branch is up-to-date."""
         make_option('--branch',
                     default="openfun/fork",
                     help='edx-platform branch to fetch the templates from.'),
-        make_option('--reverse',
+        make_option('--to-edx',
                     action='store_true',
                     default=False,
                     help='Override the edX templates with the templates from fun-apps'),
@@ -117,13 +117,13 @@ this script, make sure your openfun/fork branch is up-to-date."""
         self.edx_repo_path = options['edx_repo']
         self.is_verbose = options['verbose']
 
-        self.override_all(OVERRIDDEN_TEMPLATES, options['fun_repo'], reverse=options["reverse"])
-        self.override_all(OVERRIDDEN_THEME_TEMPLATES, options['theme_repo'], reverse=options["reverse"])
+        self.override_all(OVERRIDDEN_TEMPLATES, options['fun_repo'], to_edx=options["to_edx"])
+        self.override_all(OVERRIDDEN_THEME_TEMPLATES, options['theme_repo'], to_edx=options["to_edx"])
 
-    def override_all(self, templates_to_override, dst_dir, reverse=False):
+    def override_all(self, templates_to_override, dst_dir, to_edx=False):
         for edx_relative_path, dst_relative_path in templates_to_override:
             dst_path = os.path.abspath(os.path.join(dst_dir, dst_relative_path))
-            if reverse:
+            if to_edx:
                 self.reverse_override(edx_relative_path, dst_path)
             else:
                 self.override(edx_relative_path, dst_path)

--- a/fun/management/commands/override-templates.py
+++ b/fun/management/commands/override-templates.py
@@ -124,11 +124,11 @@ this script, make sure your openfun/fork branch is up-to-date."""
         for edx_relative_path, dst_relative_path in templates_to_override:
             dst_path = os.path.abspath(os.path.join(dst_dir, dst_relative_path))
             if to_edx:
-                self.reverse_override(edx_relative_path, dst_path)
+                self.copy_to_edx(edx_relative_path, dst_path)
             else:
-                self.override(edx_relative_path, dst_path)
+                self.copy_to_fun(edx_relative_path, dst_path)
 
-    def override(self, edx_relative_path, dst_path):
+    def copy_to_fun(self, edx_relative_path, dst_path):
         """Copy edx-platform template (from openfun/fork branch) to destination file"""
         self.log_override(dst_path, os.path.join(self.edx_repo_path, edx_relative_path))
         with cd(self.edx_repo_path):
@@ -140,7 +140,7 @@ this script, make sure your openfun/fork branch is up-to-date."""
         with open(os.path.join(dst_path), 'w') as fun_file:
             fun_file.write(file_content)
 
-    def reverse_override(self, edx_relative_path, src_path):
+    def copy_to_edx(self, edx_relative_path, src_path):
         """Copy template from src_path to edx-platform"""
         edx_path = os.path.abspath(os.path.join(self.edx_repo_path, edx_relative_path))
         self.log_override(edx_path, src_path)


### PR DESCRIPTION
A change in the override-templates command that copies templates files between edx-platform and Fun's repos.

We are renaming the "reverse" option so that it tells more explicitly that we are copying files from Fun's repos to Edx-platform's repos. In the same spirit, we are also renaming some methods.