### PR TITLE
Fix university course listing display

### DIFF
--- a/universities/templates/universities/detail.html
+++ b/universities/templates/universities/detail.html
@@ -28,7 +28,7 @@ from django.utils.translation import ugettext as _
       ${ university.description }
       </%block>
     </section>
-    <section id="courses-list" class="find-courses container">
+    <section id="courses-list" class="courses-container">
       <section class="courses">
         <ul class="courses-listing">
           % for course in courses:


### PR DESCRIPTION
Featured university courses no longer look weird. Note that the course
listing items look rather different from version 2.13. In particular,
there is no more "New" label.

This goes with https://github.com/openfun/edx-theme/pull/30