### PR TITLE
Downgrade raven version - not compatible with sentry server.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ django-ckeditor-updated==4.2.8
 django-contact-form==1.0
 django-solo==1.0.3
 unicodecsv==0.9.4
-raven==5.2.0
+raven==5.1.0
 django-pure-pagination==0.2.1
 
 # DMCloud XBlock 


### PR DESCRIPTION
Our sentry server is currently running Sentry 6.4.4. That seems not to be compatible with raven 5.2.
I have tried using raven 5.1.0 and it seems to work fine.