### PR TITLE
Re-enable dmcloud in development mode

### DIFF
--- a/fun/envs/dev.py
+++ b/fun/envs/dev.py
@@ -68,6 +68,3 @@ PIPELINE_SASS_ARGUMENTS = '--debug-info --require {proj_dir}/static/sass/bourbon
 
 ########################### DEBUG #################################
 TEMPLATE_STRING_IS_INVALID = "__INVALID__"
-
-# Disable our DM Cloud player
-USE_DM_CLOUD_VIDEO_PLAYER = False


### PR DESCRIPTION
DmCloud had been disabled for the time of the hackathon. We can now
reinstate it.