### PR TITLE
Add script to remove write permissions from wiki articles

### DIFF
--- a/fun/management/commands/remove_wiki_write_permissions.py
+++ b/fun/management/commands/remove_wiki_write_permissions.py
@@ -1,0 +1,39 @@
+from django.core.management.base import BaseCommand, CommandError
+
+import wiki.models.urlpath
+import wiki.models.article
+
+from opaque_keys.edx.keys import CourseKey
+from xmodule.modulestore.django import modulestore
+
+
+class Command(BaseCommand):
+
+    help = """Remove write authorizations from all wiki articles from the given
+courses. This should be doable via the wiki settings view, but a bug in
+django-wiki prevents inheriting read/write permission changes.
+"""
+    args = "<course_id_1> <course_id_2>..."
+
+    def handle(self, *args, **options):
+        if len(args) == 0:
+            raise CommandError("Define at least one course_id argument")
+
+        for course_key_string in args:
+            course_key = CourseKey.from_string(course_key_string)
+            course = modulestore().get_course(course_key)
+            slug = course.wiki_slug
+
+            # Note that this requires on request per argument and could be optimised
+            urlpaths = wiki.models.urlpath.URLPath.objects.select_related("article").filter(slug=slug)
+            if not urlpaths:
+                self.stdout.write("---- Wiki article '{}' could not be found\n".format(slug))
+                continue
+            for urlpath in urlpaths:
+                urlpath.article.group_write = False
+                urlpath.article.other_write = False
+                urlpath.article.save()
+                urlpath_descendants = urlpath.article.descendant_objects()
+                (wiki.models.article.Article.objects.filter(urlpath__in=urlpath_descendants)
+                                                    .update(group_write=False, other_write=False))
+                self.stdout.write("++++ Write permissions removed from wiki '{}'\n".format(slug))

--- a/fun/tests/test_remove_wiki_write_permissions.py
+++ b/fun/tests/test_remove_wiki_write_permissions.py
@@ -1,0 +1,60 @@
+from StringIO import StringIO
+
+from wiki.models.urlpath import URLPath
+from wiki.models.article import Article
+
+from course_wiki.views import get_or_create_root
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+from fun.management.commands import remove_wiki_write_permissions
+
+
+class TestRemoveWikiWritePermissions(ModuleStoreTestCase):
+
+    def setUp(self):
+        super(TestRemoveWikiWritePermissions, self).setUp()
+        self.wiki_root = get_or_create_root()
+        self.course = CourseFactory.create(org='ORG', display_name='COURSE', number='RUN')
+
+    def create_article(self, parent, slug, title):
+        return URLPath.create_article(parent, slug, title=title, article_kwargs={
+            'group_write': True,
+            'other_write': True,
+        })
+
+    def remove_write_permissions(self):
+        command = remove_wiki_write_permissions.Command()
+        command.execute(unicode(self.course.id), stdout=StringIO())
+
+    def assertHasWritePermission(self, article):
+        article = Article.objects.get(pk=article.pk)
+        self.assertTrue(article.group_write)
+        self.assertTrue(article.other_write)
+
+    def assertHasNoWritePermission(self, article):
+        article = Article.objects.get(pk=article.pk)
+        self.assertFalse(article.group_write)
+        self.assertFalse(article.other_write)
+
+    def test_remove_permissions(self):
+        # Create parent/child articles
+        wiki_course_root = self.create_article(self.wiki_root, self.course.wiki_slug, "Root article")
+        wiki_course_child = self.create_article(wiki_course_root, 'child-article', "Child article")
+
+        self.assertHasWritePermission(wiki_course_root)
+        self.assertHasWritePermission(wiki_course_child)
+        self.remove_write_permissions()
+        self.assertHasNoWritePermission(wiki_course_root)
+        self.assertHasNoWritePermission(wiki_course_child)
+
+    def test_remove_permissions_from_multiple_articles_with_same_slug(self):
+        # Create parent/child articles with identical slugs
+        wiki_course_root = self.create_article(self.wiki_root, self.course.wiki_slug, "Root article")
+        wiki_course_child_1 = self.create_article(wiki_course_root, self.course.wiki_slug, "Child article 1")
+        wiki_course_child_2 = self.create_article(wiki_course_root, 'child-article', "Child article")
+
+        self.remove_write_permissions()
+        self.assertHasNoWritePermission(wiki_course_root)
+        self.assertHasNoWritePermission(wiki_course_child_1)
+        self.assertHasNoWritePermission(wiki_course_child_2)


### PR DESCRIPTION
This script is a way around a django-wiki bug that prevents child wiki
articles from inheriting permissions from their parents.

This closes issue #1629.