### PR TITLE
Add a command to standardize certificate path in database.

### DIFF
--- a/fun/management/commands/standardize-certificate-path.py
+++ b/fun/management/commands/standardize-certificate-path.py
@@ -1,0 +1,32 @@
+from optparse import make_option
+
+from django.core.management.base import BaseCommand
+
+from certificates.models import GeneratedCertificate
+
+
+class Command(BaseCommand):
+    help = """Standardize certificate path.
+
+           Remove the static string from the certificate path.
+
+           Example:
+               `/static/attestations/attestation.pdf` become
+               `/attestations/attestation.pdf`
+           Usage:
+               ./manage.py standardize_certificate_path --settings=.. [--dry-run]
+           """
+
+    option_list = BaseCommand.option_list + (
+        make_option('--dry-run', dest='dry-run', action="store_true", default=False),)
+
+    def handle(self, *args, **options):
+        certificates = GeneratedCertificate.objects.filter(download_url__startswith='/static/')
+        self.stdout.write("{} certificates path will be modified\n".format(len(certificates)))
+        path_modified = 0
+        for certificate in certificates:
+            path_modified += 1
+            certificate.download_url = certificate.download_url[7:]
+            if not options['dry-run']:
+                certificate.save()
+        self.stdout.write("{} certificates have been modified\n".format(path_modified))

--- a/fun/management/commands/tests/test_standardize_certificate_path.py
+++ b/fun/management/commands/tests/test_standardize_certificate_path.py
@@ -1,0 +1,19 @@
+from django.core.management import call_command
+
+from certificates.tests.factories import GeneratedCertificateFactory
+from certificates.models import CertificateStatuses
+from student.tests.factories import UserFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+
+from fun.tests.utils import skipUnlessLms
+from certificates.models import GeneratedCertificate
+
+@skipUnlessLms
+class StandardizeCertificatePathTestCase(ModuleStoreTestCase):
+    def test_standardize_certifiacte_path(self):
+        GeneratedCertificateFactory(user=UserFactory(),
+                                    status=CertificateStatuses.downloadable,
+                                    download_url='/static/attestations/attestation.pdf')
+        call_command('standardize-certificate-path')
+        certificate = GeneratedCertificate.objects.get()
+        self.assertEqual(certificate.download_url, '/attestations/attestation.pdf')


### PR DESCRIPTION
En base nous avons deux liens différents vers les attestations.
/static/attestations/attestation.pdf et
/attestations/attestation.pdf`.

Ce script harmonise le lien en /attestations/attestation.pdf.

Ticket https://fun.plan.io/issues/1707