### PR TITLE
Change course API response format.

### DIFF
--- a/courses/api.py
+++ b/courses/api.py
@@ -1,17 +1,82 @@
 from rest_framework import viewsets
-from rest_framework.filters import DjangoFilterBackend
+from rest_framework.response import Response
 
-from .serializers import CourseSerializer
-from .models import Course
+from universities.models import University
+from universities.serializers import UniversitySerializer
+
+from .serializers import CourseSerializer, CourseSubjectSerializer
+from .models import Course, CourseSubject
 
 
-class CourseAPIView(viewsets.ReadOnlyModelViewSet):
-    serializer_class = CourseSerializer
-    paginate_by = 10
-    paginate_by_param = 'rpp'
-    filter_backends = (DjangoFilterBackend,)
-    filter_fields = ('universities', 'subjects', 'level')
+class CourseAPIView(viewsets.ViewSet):
+    '''
+    Returns list of courses.
 
-    def get_queryset(self):
+    ## API Response
+    The API response is a document structured like this:
+
+    ```
+    {
+        "courses": [ ],
+        "universities": [ ],
+        "course_subjects": [ ]
+    }
+    ```
+
+    The response contains, not only the list of courses, but also the list
+    of items used for filters usually displayed on sidebar - universities,
+    course subjects, etc.
+
+    ## Filtering
+
+    The API allows for filtering the list of courses.
+
+    * By universities: /api/?university=CNAM&university=CentraleParis
+    * By course subjects: /api/?subject=philosophy&subject=science
+    * By course level: /api/?level=advanced
+
+    '''
+
+    def get_courses_queryset(self):
         queryset = Course.objects.prefetch_related('subjects', 'universities')
+        university_codes = self.request.QUERY_PARAMS.getlist('university')
+        subject_slugs = self.request.QUERY_PARAMS.getlist('subject')
+        levels = self.request.QUERY_PARAMS.getlist('level')
+        if university_codes:
+            queryset = queryset.filter(universities__code__in=university_codes)
+        if subject_slugs:
+            queryset = queryset.filter(subjects__slug__in=subject_slugs)
+        if levels:
+            queryset = queryset.filter(level__in=levels)
         return queryset
+
+    def get_serialized_courses(self):
+        queryset = self.get_courses_queryset()
+        serializer = CourseSerializer(queryset, many=True)
+        return serializer.data
+
+    def get_serialized_universities(self, course_id_list=None):
+        queryset = University.objects.all()
+        if course_id_list:
+            queryset = queryset.filter(courses__id__in=course_id_list).distinct()
+        serializer = UniversitySerializer(queryset)
+        return serializer.data
+
+    def get_serialized_course_subjects(self, course_id_list=None):
+        queryset = CourseSubject.objects.all()
+        if course_id_list:
+            queryset = queryset.filter(courses__id__in=course_id_list).distinct()
+        serializer = CourseSubjectSerializer(queryset)
+        return serializer.data
+
+    def list(self, request, *args, **kwargs):
+        courses_data = self.get_serialized_courses()
+        courses_id_list = self.get_courses_queryset().values_list('id', flat=True)
+        universities_data = self.get_serialized_universities(courses_id_list)
+        course_subjects_data = self.get_serialized_course_subjects(courses_id_list)
+        data = {
+            'courses': courses_data,
+            'universities': universities_data,
+            'course_subjects': course_subjects_data,
+        }
+        return Response(data)

--- a/courses/migrations/0014_auto__add_index_coursesubject_featured.py
+++ b/courses/migrations/0014_auto__add_index_coursesubject_featured.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding index on 'CourseSubject', fields ['featured']
+        db.create_index('courses_coursesubject', ['featured'])
+
+
+    def backwards(self, orm):
+        # Removing index on 'CourseSubject', fields ['featured']
+        db.delete_index('courses_coursesubject', ['featured'])
+
+
+    models = {
+        'courses.course': {
+            'Meta': {'ordering': "('-score',)", 'object_name': 'Course'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            'level': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'subjects': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'courses'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['courses.CourseSubject']"}),
+            'universities': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'courses'", 'symmetrical': 'False', 'through': "orm['courses.CourseUniversityRelation']", 'to': "orm['universities.University']"})
+        },
+        'courses.coursesubject': {
+            'Meta': {'ordering': "('-score', 'name', 'id')", 'object_name': 'CourseSubject'},
+            'description': ('ckeditor.fields.RichTextField', [], {'blank': 'True'}),
+            'featured': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'short_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'courses.courseuniversityrelation': {
+            'Meta': {'ordering': "('order', 'id')", 'object_name': 'CourseUniversityRelation'},
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_universities'", 'to': "orm['courses.Course']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'university': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_courses'", 'to': "orm['universities.University']"})
+        },
+        'universities.university': {
+            'Meta': {'ordering': "('-score', 'id')", 'object_name': 'University'},
+            'banner': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'certificate_logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'description': ('ckeditor.fields.RichTextField', [], {'blank': 'True'}),
+            'detail_page_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'dm_api_key': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'dm_user_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': "orm['universities.University']"}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'short_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['courses']

--- a/courses/migrations/0015_auto__add_index_course_level.py
+++ b/courses/migrations/0015_auto__add_index_course_level.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding index on 'Course', fields ['level']
+        db.create_index('courses_course', ['level'])
+
+
+    def backwards(self, orm):
+        # Removing index on 'Course', fields ['level']
+        db.delete_index('courses_course', ['level'])
+
+
+    models = {
+        'courses.course': {
+            'Meta': {'ordering': "('-score',)", 'object_name': 'Course'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            'level': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'subjects': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'courses'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['courses.CourseSubject']"}),
+            'universities': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'courses'", 'symmetrical': 'False', 'through': "orm['courses.CourseUniversityRelation']", 'to': "orm['universities.University']"})
+        },
+        'courses.coursesubject': {
+            'Meta': {'ordering': "('-score', 'name', 'id')", 'object_name': 'CourseSubject'},
+            'description': ('ckeditor.fields.RichTextField', [], {'blank': 'True'}),
+            'featured': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'short_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'courses.courseuniversityrelation': {
+            'Meta': {'ordering': "('order', 'id')", 'object_name': 'CourseUniversityRelation'},
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_universities'", 'to': "orm['courses.Course']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'university': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_courses'", 'to': "orm['universities.University']"})
+        },
+        'universities.university': {
+            'Meta': {'ordering': "('-score', 'id')", 'object_name': 'University'},
+            'banner': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'certificate_logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'description': ('ckeditor.fields.RichTextField', [], {'blank': 'True'}),
+            'detail_page_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'dm_api_key': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'dm_user_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': "orm['universities.University']"}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'short_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['courses']

--- a/courses/models.py
+++ b/courses/models.py
@@ -21,7 +21,7 @@ class Course(models.Model):
     subjects = models.ManyToManyField('CourseSubject', related_name='courses',
         null=True, blank=True)
     level = models.CharField(_('level'), max_length=255,
-        choices=courses_choices.COURSE_LEVEL_CHOICES, blank=True)
+        choices=courses_choices.COURSE_LEVEL_CHOICES, blank=True, db_index=True)
     score = models.PositiveIntegerField(_('score'), default=0, db_index=True)
 
     class Meta:
@@ -76,7 +76,7 @@ class CourseSubject(models.Model):
         help_text=_('Displayed where space is rare - on side panel for instance.'))
     slug = models.SlugField(_('slug'), max_length=255, unique=True)
     description = RichTextField(_('description'), blank=True)
-    featured = models.BooleanField(verbose_name=_('featured'))
+    featured = models.BooleanField(verbose_name=_('featured'), db_index=True)
     image = models.ImageField(_("image"), upload_to="courses",
         null=True, blank=True)
     score = models.PositiveIntegerField(_('score'), default=0, db_index=True)


### PR DESCRIPTION
- The response now includes universities and course subjects - easier for sidebar display.
- Now using filter by university code instead of id.
- Now using filter by course subject slug instead of id.