### PR TITLE
Now using a custom class for staticfiles BowerFinder.

### DIFF
--- a/fun/envs/lms/common.py
+++ b/fun/envs/lms/common.py
@@ -149,7 +149,7 @@ PAGINATION_SETTINGS = {
 ACCOUNT_VISIBILITY_CONFIGURATION["default_visibility"] = "private"
 
 # We user Bower to handle our own CSS/Javascript dependencies
-STATICFILES_FINDERS += ('djangobower.finders.BowerFinder',)
+STATICFILES_FINDERS += ('fun.utils.staticfiles_finders.BowerFinder',)
 BOWER_COMPONENTS_ROOT = FUN_BASE_ROOT + '/components/'
 BOWER_PATH = '/usr/bin/bower'
 # JS libraries will be downloaded to fun-apps/components/bower_components by `fun lms.dev bower install` command,

--- a/fun/utils/staticfiles_finders.py
+++ b/fun/utils/staticfiles_finders.py
@@ -1,0 +1,28 @@
+import collections
+from staticfiles.finders import FileSystemFinder
+from django.core.files.storage import FileSystemStorage
+from djangobower import conf
+import os
+
+
+class BowerFinder(FileSystemFinder):
+    """Find static files installed with bower"""
+
+    def __init__(self, apps=None, *args, **kwargs):
+        self.locations = [
+            ('', self._get_bower_components_location()),
+        ]
+        self.storages = collections.OrderedDict()
+
+        filesystem_storage = FileSystemStorage(location=self.locations[0][1])
+        filesystem_storage.prefix = self.locations[0][0]
+        self.storages[self.locations[0][1]] = filesystem_storage
+
+    def _get_bower_components_location(self):
+        """Get bower components location"""
+        path = os.path.join(conf.COMPONENTS_ROOT, 'bower_components')
+
+        # for old bower versions:
+        if not os.path.exists(path):
+            path = os.path.join(conf.COMPONENTS_ROOT, 'components')
+        return path


### PR DESCRIPTION
Why are we using a custom BowerFinder class? The finder class provided
by django-bower uses the standard `django.contrib.staticfiles`.
There is an issue with that, because edX expects a finder class that
extends the external `staticfiles` module - not the standard
module form `contrib`. The custom finder class we are using here
is a copy of bower's finder that extends the external `staticfiles`
module.