### PR TITLE
videoproviders.libcast: fix cache management

### DIFF
--- a/fun/envs/cms/common.py
+++ b/fun/envs/cms/common.py
@@ -78,5 +78,4 @@ def IS_VIDEOUPLOAD_DASHBOARD_ENABLED(course_id):
     Args:
         course_id (CourseKey)
     """
-    return False
-    # return course_id.org in ['FUN', 'Org']
+    return True

--- a/fun/envs/common.py
+++ b/fun/envs/common.py
@@ -148,7 +148,7 @@ PASSWORD_COMPLEXITY = {
 
 
 # Set this to either 'dmcloud', 'libcast_xblock' or None.
-FUN_DEFAULT_VIDEO_PLAYER = 'dmcloud'
+FUN_DEFAULT_VIDEO_PLAYER = 'libcast_xblock'
 
 def prefer_fun_xmodules(identifier, entry_points):
     """

--- a/fun/envs/common.py
+++ b/fun/envs/common.py
@@ -245,7 +245,6 @@ CACHES = {
     "celery": default_cache_configuration("integration_celery"),
     "default": default_cache_configuration("sandbox_default"),
     "general": default_cache_configuration("sandbox_general"),
-    "libcast": default_cache_configuration("libcast"),
     "video_subtitles": file_cache_configuration(
         "video_subtitles",
         "video_subtitles_cache"

--- a/fun/envs/dev.py
+++ b/fun/envs/dev.py
@@ -18,9 +18,6 @@ TEMPLATE_DEBUG = True
 # By default don't use a worker, execute tasks as if they were local functions
 CELERY_ALWAYS_EAGER = True
 
-# use libcast in development mode
-FUN_DEFAULT_VIDEO_PLAYER = 'libcast_xblock'
-
 ################################ LOGGERS ######################################
 
 import logging

--- a/fun/management/commands/list_dmcloud_videos.py
+++ b/fun/management/commands/list_dmcloud_videos.py
@@ -44,7 +44,7 @@ def get_videos(course):
     videos = []
     for item in modulestore().get_items(course.id):
         if item.category in ['video', 'dmcloud']:
-            if item.id_video:
+            if getattr(item, 'id_video', None):
                 videos.append({
                     "dmcloud_id": item.id_video,
                     "display_name": item.display_name

--- a/videoproviders/admin.py
+++ b/videoproviders/admin.py
@@ -12,3 +12,9 @@ class DailymotionAuthAdminInline(admin.StackedInline):
 class LibcastAuthAdminInline(admin.StackedInline):
     model = models.LibcastAuth
     fields = ("username", "api_key",)
+
+
+class LibcastCourseSettingsAdmin(admin.ModelAdmin):
+    list_display = ('course',)
+
+admin.site.register(models.LibcastCourseSettings, LibcastCourseSettingsAdmin)

--- a/videoproviders/api/base.py
+++ b/videoproviders/api/base.py
@@ -96,6 +96,25 @@ class BaseClient(object):
     def delete(self, endpoint, params=None):
         return self.request(endpoint, method='DELETE', params=params)
 
+    def safe_get(self, endpoint, params=None, message=''):
+        return self.safe_request(endpoint, params=params, message=message)
+
+    def safe_post(self, endpoint, params=None, files=None, message=''):
+        return self.safe_request(endpoint, method='POST', params=params, files=files, message=message)
+
+    def safe_put(self, endpoint, params=None, files=None, message=''):
+        return self.safe_request(endpoint, method='PUT', params=params, files=files, message=message)
+
+    def safe_delete(self, endpoint, params=None, message=''):
+        return self.safe_request(endpoint, method='DELETE', params=params, message=message)
+
+    # pylint: disable=too-many-arguments
+    def safe_request(self, endpoint, method='GET', params=None, files=None, message=''):
+        response = self.request(endpoint, method=method, params=params, files=files)
+        if response.status_code >= 400:
+            raise ClientError(message)
+        return response
+
     #################################
     # Methods to implement start here
     #################################

--- a/videoproviders/api/libcast.py
+++ b/videoproviders/api/libcast.py
@@ -88,23 +88,23 @@ class LibcastAccountVerifierMixin(object):
     verified when the key expires.
     """
 
-    CACHE = get_cache("libcast")
-    # The libcast account will be verified with this periodicity, in seconds
-    LIBCAST_CONFIG_CHECK_PERIOD = 24*60*60
-
+    # The libcast account will be verified with this periodicity
+    LIBCAST_CONFIG_CHECK_PERIOD_SECONDS = 24*60*60
+    CACHE_NAME = 'libcast'
 
     def ensure_course_is_configured(self):
         """
         Make sure that everything is ready in the Libcast account for upload.
 
-        This should run on every CMS instance every LIBCAST_CONFIG_CHECK_PERIOD seconds.
+        This will run on every CMS instance every LIBCAST_CONFIG_CHECK_PERIOD_SECONDS.
         """
-        if not self.CACHE.get(self.course_key_string):
+        cache = get_cache(self.CACHE_NAME)
+        if not cache.get(self.course_key_string):
             self.ensure_course_directory_exists()
             self.ensure_stream_exists(self.org)
             self.ensure_stream_exists(self.course_key_string,
                                       parent_stream=self.org)
-            self.CACHE.set(self.course_key_string, self.LIBCAST_CONFIG_CHECK_PERIOD)
+            cache.set(self.course_key_string, self.LIBCAST_CONFIG_CHECK_PERIOD_SECONDS)
 
     def ensure_course_directory_exists(self):
         """Check for the existence of a folder (possibly in a subdirectory) and create it if necessary.

--- a/videoproviders/api/libcast.py
+++ b/videoproviders/api/libcast.py
@@ -77,9 +77,6 @@ class LibcastUrls(object):
         path = self.resource_path(video_id) + "/flavor/video/fun-{}.mp4".format(slugify(label))
         return self.fun_libcast_url(path)
 
-    def thumbnail_url(self, video_id):
-        return self.libcast_url(self.resource_path(video_id) + "/thumbnail/thumb.jpg")
-
 
 class LibcastAccountVerifierMixin(object):
     """
@@ -253,7 +250,7 @@ class Client(BaseClient, LibcastAccountVerifierMixin):
             'title':  resource.find('title').text,
             'subtitles': self.get_resource_subtitles(resource),
             'status': status,
-            'thumbnail_url': resource.find('thumbnail').text,
+            'thumbnail_url': self.get_resource_thumbnail_url(resource),
             'video_sources': video_sources,
             'external_link': external_link
         }
@@ -401,6 +398,9 @@ class Client(BaseClient, LibcastAccountVerifierMixin):
     def get_video_subtitles(self, video_id):
         resource = self.get_resource(video_id)
         return self.get_resource_subtitles(resource)
+
+    def get_resource_thumbnail_url(self, resource):
+        return resource.find('thumbnail').text
 
     def get_resource_subtitles(self, resource):
         """Get the subtitles associated to a resource

--- a/videoproviders/migrations/0003_auto__add_libcastcoursesettings.py
+++ b/videoproviders/migrations/0003_auto__add_libcastcoursesettings.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'LibcastCourseSettings'
+        db.create_table('videoproviders_libcastcoursesettings', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('course', self.gf('django.db.models.fields.CharField')(unique=True, max_length=200)),
+            ('directory_slug', self.gf('django.db.models.fields.CharField')(max_length=200)),
+            ('stream_slug', self.gf('django.db.models.fields.CharField')(max_length=200)),
+        ))
+        db.send_create_signal('videoproviders', ['LibcastCourseSettings'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'LibcastCourseSettings'
+        db.delete_table('videoproviders_libcastcoursesettings')
+
+
+    models = {
+        'universities.university': {
+            'Meta': {'ordering': "('order', 'id')", 'object_name': 'University'},
+            'banner': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'certificate_logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'description': ('ckeditor.fields.RichTextField', [], {'blank': 'True'}),
+            'dm_api_key': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'dm_user_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'featured': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': "orm['universities.University']"}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255', 'blank': 'True'})
+        },
+        'videoproviders.dailymotionauth': {
+            'Meta': {'object_name': 'DailymotionAuth'},
+            'access_token': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'api_key': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'api_secret': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'expires_at': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'refresh_token': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'university': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['universities.University']", 'unique': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'videoproviders.libcastauth': {
+            'Meta': {'object_name': 'LibcastAuth'},
+            'api_key': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'university': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['universities.University']", 'unique': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'videoproviders.libcastcoursesettings': {
+            'Meta': {'object_name': 'LibcastCourseSettings'},
+            'course': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            'directory_slug': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'stream_slug': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        }
+    }
+
+    complete_apps = ['videoproviders']

--- a/videoproviders/models.py
+++ b/videoproviders/models.py
@@ -46,3 +46,20 @@ class LibcastAuth(models.Model):
     api_key = models.CharField(verbose_name=_("API key"), max_length=255)
 
     objects = AuthManager()
+
+
+class LibcastCourseSettings(models.Model):
+    """
+    Store the libcast settings for each course. This object will be created
+    if necessary but can be modified by the support team.
+    """
+    course = models.CharField(verbose_name=_("Course ID"), max_length=200, unique=True)
+
+    # Directory in which the course files are stored
+    directory_slug = models.CharField(verbose_name=_("Libcast directory slug"), max_length=200)
+
+    # Stream in which the course resources are stored
+    stream_slug = models.CharField(verbose_name=_("Libcast stream slug"), max_length=200)
+
+    class Meta:
+        verbose_name_plural = _("Libcast course settings")


### PR DESCRIPTION
- CACHE static variable was being loaded at import time, which is too early.
- parent stream lookup was incorrect for streams with unpredictable name