### PR TITLE
Various improvements in enrollments stats

### DIFF
--- a/course_dashboard/templates/course_dashboard/enrollment-stats-content.html
+++ b/course_dashboard/templates/course_dashboard/enrollment-stats-content.html
@@ -8,26 +8,19 @@
 </div>
 
 <div class="row">
-    <div class="thumbnail col-md-3 key-stats">
+    <div class="thumbnail col-md-4 key-stats">
         <h2>&nbsp;</h2>
         <h1>${total_population}</h1>
         <h2>${_("students enrolled over %d days") % day_span}</h2>
     </div>
     %if best_day:
-    <div class="thumbnail col-md-3 key-stats">
+    <div class="thumbnail col-md-4 key-stats">
         <h2>${_("Day with most enrollments:")}</h2>
         <h1>${best_day[0]}</h1>
         <h2>${_("%d enrollments") % best_day[1]}</h2>
     </div>
     %endif
-    %if worst_day:
-    <div class="thumbnail col-md-3 key-stats">
-        <h2>${_("Day with least enrollments:")}</h2>
-        <h1>${worst_day[0]}</h1>
-        <h2>${_("%d enrollments") % worst_day[1]}</h2>
-    </div>
-    %endif
-    <div class="thumbnail col-md-3 key-stats">
+    <div class="thumbnail col-md-4 key-stats">
         <h2>&nbsp;</h2>
         <h2>${_("An average of")}</h2>
         <h1>${"%.2f" % average_enrollments_per_day}</h1>

--- a/course_dashboard/templates/course_dashboard/graph.html
+++ b/course_dashboard/templates/course_dashboard/graph.html
@@ -47,7 +47,8 @@
         $("#${figure_id}").bind("plothover", function (event, pos, item) {
             if (item) {
                 var count = item.datapoint[1];
-                $("#figure-tooltip").html(count)
+                var date = new Date(item.datapoint[0]).toLocaleDateString();
+                $("#figure-tooltip").html(count + " - " + date)
                     .css({top: item.pageY-30, left: item.pageX+5})
                     .fadeIn(200);
             } else {

--- a/course_dashboard/tests/test_stats.py
+++ b/course_dashboard/tests/test_stats.py
@@ -70,6 +70,15 @@ class StatsTestCase(BaseCourseDashboardTestCase):
         course_population = stats.population_by_country(self.get_course_id(course))
         self.assertEqual({'FR': 1}, course_population)
 
+    def test_add_days_with_no_enrollments(self):
+        enrollments_per_day = [(datetime(year=2015, month=2, day=1), 5),
+                               (datetime(year=2015, month=2, day=3), 5),
+                               (datetime(year=2015, month=2, day=5), 5)]
+        enrollments_per_day = stats.add_days_with_no_enrollments(enrollments_per_day)
+        self.assertEqual(enrollments_per_day[1], (datetime(year=2015, month=2, day=2), 0))
+        self.assertEqual(enrollments_per_day[3], (datetime(year=2015, month=2, day=4), 0))
+        self.assertEqual(enrollments_per_day[4], (datetime(year=2015, month=2, day=5), 5))
+
     def test_inactive_enrollments_are_not_included(self):
         course = CourseFactory.create()
         self.enroll_student(course, user__profile__country='FR', user__is_active=False)

--- a/course_dashboard/views.py
+++ b/course_dashboard/views.py
@@ -43,10 +43,8 @@ def enrollment_stats_response(request, enrollments, template):
 def enrollment_stats_context(enrollments):
     enrollments_per_day, enrollments_per_timestamp = formatted_dates(enrollments.per_date)
     best_day = None
-    worst_day = None
     if enrollments_per_day:
         best_day = max(enrollments_per_day, key=lambda e: e[1])
-        worst_day = min(enrollments_per_day, key=lambda e: e[1])
 
     return {
         "active_tab": "enrollment_stats",
@@ -55,7 +53,6 @@ def enrollment_stats_context(enrollments):
         "enrollments_per_timestamp": enrollments_per_timestamp,
         "average_enrollments_per_day": enrollments.daily_average(),
         "best_day": best_day,
-        "worst_day": worst_day,
         "total_population": enrollments.total(),
         "day_span": enrollments.day_span(),
     }


### PR DESCRIPTION
Plusieurs améliorations apportées aux statistiques d'inscriptions du course_dashboard.

* Afficher les jours sans inscriptions (ticket https://fun.plan.io/issues/1494).
* Ajout de la date au survol d'un point du graphe.
* Suppression de la statistique concernant le jour avec le moins d'inscriptions.