### PR TITLE
Add more fields to course SQL table - instead of using Mongodb.

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -14,8 +14,9 @@ class CourseUniversityRelationInline(admin.TabularInline):
 
 
 class CourseAdmin(admin.ModelAdmin):
-    list_display = ('key', 'level', 'score', 'is_new', 'on_demand',
-        'is_active', 'prevent_auto_update', 'modification_date')
+    list_display = ('key', 'title', 'level', 'score', 'is_new',
+        'on_demand', 'is_active', 'prevent_auto_update',
+        'modification_date')
     list_filter = ('is_active', 'prevent_auto_update', 'is_new',
         'on_demand','level', 'subjects', 'universities')
     search_fields = ('key', 'certificateteacher_related__teacher__full_name',
@@ -31,6 +32,9 @@ class CourseAdmin(admin.ModelAdmin):
         (None, {
             'fields': (
                 'key',
+                'title',
+                'image_url',
+                'short_description',
                 'level',
                 'subjects',
                 'score',

--- a/courses/management/commands/update_courses.py
+++ b/courses/management/commands/update_courses.py
@@ -2,9 +2,12 @@ import random
 
 from django.core.management.base import BaseCommand
 
+from opaque_keys.edx.locator import CourseLocator
+from xmodule.contentstore.content import StaticContent
 from xmodule.modulestore.django import modulestore
 
 from courses.models import Course
+from courses.utils import get_about_section
 
 
 class Command(BaseCommand):
@@ -24,6 +27,24 @@ class Command(BaseCommand):
     def find_out_if_course_is_on_demand(self):
         return random.choice([True, False])
 
+    def get_course_title(self, course_descriptor):
+        title = get_about_section(course_descriptor, 'title')
+        return title or ''
+
+    def get_course_description(self, course_descriptor):
+        description = get_about_section(
+            course_descriptor, 'short_description'
+        )
+        return description or ''
+
+    def get_course_image_url(self, course_descriptor):
+        key = unicode(course_descriptor.id)
+        course_locator = CourseLocator.from_string(key)
+        location = StaticContent.compute_location(
+            course_locator, course_descriptor.course_image
+        )
+        return location.to_deprecated_string()
+
     def update_course_data(self):
         '''
         For each course found in Mongo database, we create or update
@@ -38,6 +59,9 @@ class Command(BaseCommand):
                 continue
             if was_created:
                 course.is_active = True
+            course.title = self.get_course_title(mongo_course)
+            course.short_description = self.get_course_description(mongo_course)
+            course.image_url = self.get_course_image_url(mongo_course)
             course.score = self.get_course_score()
             course.start_date = mongo_course.start
             course.end_date = mongo_course.end

--- a/courses/migrations/0023_auto__add_field_course_title.py
+++ b/courses/migrations/0023_auto__add_field_course_title.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Course.title'
+        db.add_column('courses_course', 'title',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=255, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Course.title'
+        db.delete_column('courses_course', 'title')
+
+
+    models = {
+        'courses.course': {
+            'Meta': {'ordering': "('-score',)", 'object_name': 'Course'},
+            'end_date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_new': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            'level': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'modification_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'on_demand': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'prevent_auto_update': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'start_date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'subjects': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'courses'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['courses.CourseSubject']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'universities': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'courses'", 'symmetrical': 'False', 'through': "orm['courses.CourseUniversityRelation']", 'to': "orm['universities.University']"})
+        },
+        'courses.coursesubject': {
+            'Meta': {'ordering': "('-score', 'name', 'id')", 'object_name': 'CourseSubject'},
+            'description': ('ckeditor.fields.RichTextField', [], {'blank': 'True'}),
+            'featured': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'short_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'courses.courseuniversityrelation': {
+            'Meta': {'ordering': "('order', 'id')", 'object_name': 'CourseUniversityRelation'},
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_universities'", 'to': "orm['courses.Course']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'university': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_courses'", 'to': "orm['universities.University']"})
+        },
+        'universities.university': {
+            'Meta': {'ordering': "('-score', 'id')", 'object_name': 'University'},
+            'banner': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'certificate_logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'description': ('ckeditor.fields.RichTextField', [], {'blank': 'True'}),
+            'detail_page_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'dm_api_key': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'dm_user_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': "orm['universities.University']"}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'short_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['courses']

--- a/courses/migrations/0024_auto__add_field_course_short_description.py
+++ b/courses/migrations/0024_auto__add_field_course_short_description.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Course.short_description'
+        db.add_column('courses_course', 'short_description',
+                      self.gf('django.db.models.fields.TextField')(default='', blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Course.short_description'
+        db.delete_column('courses_course', 'short_description')
+
+
+    models = {
+        'courses.course': {
+            'Meta': {'ordering': "('-score',)", 'object_name': 'Course'},
+            'end_date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_new': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            'level': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'modification_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'on_demand': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'prevent_auto_update': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'short_description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'start_date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'subjects': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'courses'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['courses.CourseSubject']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'universities': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'courses'", 'symmetrical': 'False', 'through': "orm['courses.CourseUniversityRelation']", 'to': "orm['universities.University']"})
+        },
+        'courses.coursesubject': {
+            'Meta': {'ordering': "('-score', 'name', 'id')", 'object_name': 'CourseSubject'},
+            'description': ('ckeditor.fields.RichTextField', [], {'blank': 'True'}),
+            'featured': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'short_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'courses.courseuniversityrelation': {
+            'Meta': {'ordering': "('order', 'id')", 'object_name': 'CourseUniversityRelation'},
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_universities'", 'to': "orm['courses.Course']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'university': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_courses'", 'to': "orm['universities.University']"})
+        },
+        'universities.university': {
+            'Meta': {'ordering': "('-score', 'id')", 'object_name': 'University'},
+            'banner': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'certificate_logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'description': ('ckeditor.fields.RichTextField', [], {'blank': 'True'}),
+            'detail_page_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'dm_api_key': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'dm_user_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': "orm['universities.University']"}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'short_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['courses']

--- a/courses/migrations/0025_auto__add_field_course_image_url.py
+++ b/courses/migrations/0025_auto__add_field_course_image_url.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Course.image_url'
+        db.add_column('courses_course', 'image_url',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=255, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Course.image_url'
+        db.delete_column('courses_course', 'image_url')
+
+
+    models = {
+        'courses.course': {
+            'Meta': {'ordering': "('-score',)", 'object_name': 'Course'},
+            'end_date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image_url': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_new': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            'level': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'modification_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'on_demand': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'prevent_auto_update': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'short_description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'start_date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'subjects': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'courses'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['courses.CourseSubject']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'universities': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'courses'", 'symmetrical': 'False', 'through': "orm['courses.CourseUniversityRelation']", 'to': "orm['universities.University']"})
+        },
+        'courses.coursesubject': {
+            'Meta': {'ordering': "('-score', 'name', 'id')", 'object_name': 'CourseSubject'},
+            'description': ('ckeditor.fields.RichTextField', [], {'blank': 'True'}),
+            'featured': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'short_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'courses.courseuniversityrelation': {
+            'Meta': {'ordering': "('order', 'id')", 'object_name': 'CourseUniversityRelation'},
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_universities'", 'to': "orm['courses.Course']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'university': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_courses'", 'to': "orm['universities.University']"})
+        },
+        'universities.university': {
+            'Meta': {'ordering': "('-score', 'id')", 'object_name': 'University'},
+            'banner': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'certificate_logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'description': ('ckeditor.fields.RichTextField', [], {'blank': 'True'}),
+            'detail_page_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'dm_api_key': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'dm_user_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': "orm['universities.University']"}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'short_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['courses']

--- a/courses/models.py
+++ b/courses/models.py
@@ -18,6 +18,9 @@ class Course(models.Model):
     modification_date = models.DateTimeField(_('modification date'), auto_now=True)
     key = models.CharField(max_length=200, verbose_name=_(u'Course key'),
         unique=True)
+    title = models.CharField(_(u'title'), max_length=255, blank=True)
+    short_description = models.TextField(_('short description'), blank=True)
+    image_url = models.CharField(_(u'image url'), max_length=255, blank=True)
     universities = models.ManyToManyField('universities.University',
         through='CourseUniversityRelation', related_name='courses')
     subjects = models.ManyToManyField('CourseSubject', related_name='courses',
@@ -43,46 +46,6 @@ class Course(models.Model):
         ordering = ('-score',)
         verbose_name = _('course')
         verbose_name_plural = _('courses')
-
-    @property
-    def course_locator(self):
-        return CourseLocator.from_string(self.key)
-
-    @property
-    def course_descriptor(self):
-        try:
-            course = get_course(self.course_locator)
-        except ValueError:
-            course = None
-        return course
-
-    @property
-    def image_url(self):
-        return 'TODO - Fix this URL'
-        if not self.course_descriptor:
-            return ''
-        location = StaticContent.compute_location(
-            self.course_locator, self.course_descriptor.course_image
-        )
-        return location.to_deprecated_string()
-
-    @property
-    def title(self):
-        return 'TODO - Fix this title'
-        if not self.course_descriptor:
-            return ''
-        title = get_course_about_section(self.course_descriptor, 'title')
-        return title
-
-    @property
-    def short_description(self):
-        return 'TODO - Fix this description'
-        if not self.course_descriptor:
-            return ''
-        description = get_course_about_section(
-            self.course_descriptor, 'short_description'
-        )
-        return description
 
     @staticmethod
     def random_featured(limit_to=7):

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -16,9 +16,6 @@ class CourseSubjectSerializer(CoursesCountSerializerMixin, serializers.ModelSeri
 class CourseSerializer(serializers.ModelSerializer):
     universities = UniversitySerializer()
     subjects = CourseSubjectSerializer()
-    image_url = serializers.CharField(source='image_url')
-    short_description = serializers.CharField(source='short_description')
-    title = serializers.CharField(source='title')
 
     class Meta:
         model = Course


### PR DESCRIPTION
* Course title is now retrieved from SQL table instead of MongoDB.
* Course short description is now retrieved from SQL table instead of Mongodb.
* Course image url is now retrieved from SQL table instead of MongoDB.