### PR TITLE
libcast: accelerate resource listing

### DIFF
--- a/videoproviders/api/libcast.py
+++ b/videoproviders/api/libcast.py
@@ -377,8 +377,12 @@ class Client(BaseClient):
         sync.
         """
         # Find course resources
-        resources = parse_xml(
-            self.safe_get(self.urls.stream_resources_path(self.stream_slug),
+        resources = parse_xml(self.safe_get(
+            self.urls.stream_resources_path(self.stream_slug),
+            params={
+                "without-views": "true",
+                "without-usages": "true",
+            },
             message=_("Could not list videos")
         ))
         # file href -> resource dict


### PR DESCRIPTION
Resource listing is accelerated by removing information about view count
and usages in the API call.

This closes issue #2046.