### PR TITLE
lms: fix theme url on landing page

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -130,11 +130,6 @@ class CourseSubject(models.Model):
         verbose_name = _('Course Subject')
         verbose_name_plural = _('Course Subjects')
 
-    def get_absolute_url(self):
-        url = reverse('fun-courses:index')
-        url = format('{}#filter/subject/{}/'.format(url, self.slug))
-        return url
-
     def get_short_name(self):
         return self.short_name or self.name
 

--- a/courses/tests/test_models.py
+++ b/courses/tests/test_models.py
@@ -56,4 +56,3 @@ class TestCourseSubject(TestCase):
         course_new = factories.CourseFactory.create(session_number=1)
         new_courses = list(models.Course.objects.new())
         self.assertEqual([course_new], new_courses)
-

--- a/courses_api/tests/test_pages.py
+++ b/courses_api/tests/test_pages.py
@@ -13,3 +13,7 @@ class CourseListTest(TestCase):
         url = reverse('fun-courses:index')
         response = self.client.get(url)
         self.assertContains(response, 'courses')
+
+    def test_filter_url(self):
+        url = reverse('fun-courses:filter', kwargs={'subject': 'physics'})
+        self.assertEqual("/cours/#filter/subject/physics", url)

--- a/courses_api/urls.py
+++ b/courses_api/urls.py
@@ -9,6 +9,7 @@ from .api import CourseAPIView
 
 urlpatterns = patterns('',
     url(r'^$', courses_index, name='index'),
+    url(r'^#filter/subject/(?P<subject>.+)$', courses_index, name='filter'),
     url(r'^feed/$', CoursesFeed(), name='feed'),
 )
 

--- a/courses_api/views.py
+++ b/courses_api/views.py
@@ -15,7 +15,11 @@ from courses.managers import annotate_with_public_courses
 import courses.utils
 
 
-def courses_index(request):
+def courses_index(request, subject=None):
+    """
+    Args:
+        subject (str): subject slug that allows to reverse course filtering urls.
+    """
     return render_to_response('courses_api/index.html', {
         "course_subjects": annotate_with_public_courses(CourseSubject.objects.by_score()),
         "universities": annotate_with_public_courses(University.objects.active_by_score()),

--- a/funsite/templates/lms/index.html
+++ b/funsite/templates/lms/index.html
@@ -228,7 +228,7 @@ news = top_news(5)
 
                 %for subject in course_subjects:
                 <div class="item">
-                    <a href="${subject.get_absolute_url()}">
+                    <a href="${reverse('fun-courses:filter', kwargs={'subject': subject.slug})}">
                         <div>
                             <h3>${subject.name}</h3>
                             <img src="${subject.image.url}" alt="${subject.name}">


### PR DESCRIPTION
Theme url ended with an extra "/". This was fixed by moving the relevant
code to courses_api, which is lms-only.

This closes issue #2103.