### PR TITLE
landing page: make sure the image occupies 100% of the page width

### DIFF
--- a/funsite/templates/funsite/parts/base.html
+++ b/funsite/templates/funsite/parts/base.html
@@ -44,11 +44,7 @@ from staticfiles.storage import staticfiles_storage
 <%include file="menu.html" args="base_application='funsite'"/>
 
 
-<div class="container-fluid">
-
-    <%block name="content_fullwidth"></%block>
-
-</div>
+<%block name="content_fullwidth"></%block>
 
 <div class="<%block name='main_div_class'></%block>">
 


### PR DESCRIPTION
This closes issue #2141.