### PR TITLE
Fix video teaser in course about page

### DIFF
--- a/fun/utils/__init__.py
+++ b/fun/utils/__init__.py
@@ -26,8 +26,14 @@ def get_fun_course(course):
     from courses.models import Course
     return Course.objects.get(key=course.id.to_deprecated_string())
 
-def get_teaser(course, video_id):
-    """Build the DailyMotion url from the video_id and return the html snippet"""
+def get_teaser(video_id, autoplay=False, force_html=False):
+    """Build the DailyMotion url from the video_id and return the html snippet.
+
+    The teaser will be an HTML5 video that will auto-play.
+
+    Args:
+        video_id (str)
+    """
     if len(video_id) > 20:
         # Studio saves in mongo youtube urls with dmcloud id, we have to extract dmclouid to build correct url
         try:
@@ -37,9 +43,13 @@ def get_teaser(course, video_id):
     else:
         # FUN v1 did the stuff right
         dm_id = video_id
-    html = '<iframe id="course-teaser" frameborder="0" scrolling="no" allowfullscreen="" src="//www.dailymotion.com/embed/video/%s/?&api=postMessage"></iframe>' % (
-            dm_id)
-    return html
+
+    return (
+        '<iframe id="course-teaser" '
+        'frameborder="0" scrolling="no" allowfullscreen="" '
+        'src="//www.dailymotion.com/embed/video/{dm_id}/?html&autoplay=1"'
+        '></iframe>'
+    ).format(dm_id=dm_id)
 
 def registration_datetime_text(course, date):
     """Returns the registration date for the course formatted as a string."""

--- a/funsite/templates/lms/courseware/course_about.html
+++ b/funsite/templates/lms/courseware/course_about.html
@@ -8,27 +8,29 @@ from courseware.courses import course_image_url, get_course_about_section
 from microsite_configuration import microsite
 
 from fun.utils import get_fun_course, get_teaser, registration_datetime_text
-
 %>
 
 <%inherit file="/funsite/parts/base-fixed-width.html" />
 
 <%block name="js_extra">
+
 <script>
 (function() {
+    // Configure video teaser player
     $('.video-button').on('click', function() {
+        var teaserHtml = '${get_teaser(get_course_about_section(course, "video"))}';
         $('#video-modal').modal('show');
-    })
-    $('#video-modal').on('shown.bs.modal', function() {
-        $('iframe#course-teaser')[0].contentWindow.postMessage('play', '*');
+        $('#video-modal .inner-wrapper').html(teaserHtml);
     })
     $('#video-modal').on('hide.bs.modal', function() {
-        $('iframe#course-teaser')[0].contentWindow.postMessage('pause', '*');
-        $('iframe#course-teaser')[0].contentWindow.postMessage('seek=0', '*');
-    })
-    $('div.teacher-image img').addClass('img-circle')
-    $('.social-networks div>a').attr('target', '_blank');
+        $('#video-modal .inner-wrapper').html("");
+    });
 
+    $('div.teacher-image img').addClass('img-circle');
+
+    // Open social links included by course designers in their syllabus in a
+    // different tab.
+    $('.social-networks div>a').attr('target', '_blank');
 
     $(".register").click(function(event) {
         var url = '${reverse("change_enrollment")}',
@@ -126,12 +128,9 @@ from fun.utils import get_fun_course, get_teaser, registration_datetime_text
 
     <div class="row">
 
-
         <div class="col-lg-15 col-sm-10 col-lg-push-21 col-sm-push-26 no-gutter-left no-padding">
 
             <div class="right">
-
-
 
                 <div class="text-center hidden-sm hidden-md hidden-lg">
                     ${breadcrumbs.breadcrumbs(get_course_about_section(course, 'title'))}
@@ -146,9 +145,6 @@ from fun.utils import get_fun_course, get_teaser, registration_datetime_text
                     <div class="video-button"></div>
                     <img src="${ fun_course.get_thumbnail_url('about') }" class="img-responsive">
                 </div>
-
-
-
 
                 <div class="course-about-university-logo">
                     % if fun_course.universities.exists():
@@ -337,9 +333,7 @@ from fun.utils import get_fun_course, get_teaser, registration_datetime_text
 <div class="modal fade" id="video-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
-            <div class="inner-wrapper">
-                ${get_teaser(course, get_course_about_section(course, "video"))}
-            </div>
+            <div class="inner-wrapper"></div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
There were two issues with the former way of doing:
- Flash-based videos are regularly blocked by firefox for security reasons.
- The Dailymotion postMessage API did not allow us to detect player
  events, so trying to play the video too early resulted in javascript errors.

Both these issues prevented video playing in Firefox. To circumvent this
problem, we get rid of flash format and we load the video in a different
way: the modal is filled with the iframe html code every time the modal
is shown. The iframe is created with an autoplay parameter so the videos
starts playing right after the video is loaded.

This closes issue #2178.