### PR TITLE
Regisb/modal login csrf

### DIFF
--- a/fun/envs/lms/common.py
+++ b/fun/envs/lms/common.py
@@ -163,15 +163,15 @@ ACCOUNT_VISIBILITY_CONFIGURATION["default_visibility"] = "private"
 SOUTH_MIGRATION_MODULES['easy_thumbnails'] = 'easy_thumbnails.south_migrations'
 
 # Add our v3 CSS and JS files to assets compilation pipeline to make them available in courseware.
-# On FUN v3 frontend, which do not use edX's templates, those files are loaded by funsite/templates/funsite/parts/base.html
-# css/lms-main.css
+# On FUN v3 frontend, which do not use edX's templates, those files are loaded
+# by funsite/templates/funsite/parts/base.html and css/lms-main.css
 
+PIPELINE_CSS['style-main']['source_filenames'].append('fun/css/cookie-banner.css')
 PIPELINE_CSS['style-main']['source_filenames'].append('funsite/css/header.css')
 PIPELINE_CSS['style-main']['source_filenames'].append('funsite/css/footer.css')
-PIPELINE_CSS['style-main']['source_filenames'].append('fun/css/cookie-banner.css')
 PIPELINE_CSS['style-main']['source_filenames'].append('forum_contributors/highlight/css/highlight.css')
 
 
 # js/lms-application.js
-PIPELINE_JS['application']['source_filenames'].append('funsite/js/header.js')
 PIPELINE_JS['application']['source_filenames'].append('fun/js/cookie-banner.js')
+PIPELINE_JS['application']['source_filenames'].append('funsite/js/header.js')

--- a/fun/static/fun/js/cookie-banner.js
+++ b/fun/static/fun/js/cookie-banner.js
@@ -1,22 +1,24 @@
+// Note: this function should probably be in a separate script file, as it is
+// used elsewhere.
+function checkCookie(name) {
+    var nameEQ = name + "=";
+    var ca = document.cookie.split(';');
+    for (var i=0;i < ca.length;i++) {
+        var c = ca[i];
+        while (c.charAt(0)==' ') {
+            c = c.substring(1,c.length);
+        }
+        if (c.indexOf(nameEQ) === 0) {
+            return c.substring(nameEQ.length,c.length);
+        }
+    }
+    return null;
+}
+
 (function() {
     var cookieName = 'acceptCookieFun';
     var cookieValue = "on";
     var cookieDuration = 365;
-
-    function checkCookie(name) {
-        var nameEQ = name + "=";
-        var ca = document.cookie.split(';');
-        for (var i=0;i < ca.length;i++) {
-            var c = ca[i];
-            while (c.charAt(0)==' ') {
-                c = c.substring(1,c.length);
-            }
-            if (c.indexOf(nameEQ) === 0) {
-                return c.substring(nameEQ.length,c.length);
-            }
-        }
-        return null;
-    }
 
     function removeDiv(event) {
         event.preventDefault();

--- a/funsite/static/funsite/js/fun.js
+++ b/funsite/static/funsite/js/fun.js
@@ -6,13 +6,13 @@
     $('#sandwich-overlay [data-location="'+ page +'"]').addClass('selected');
 
     /* Login overlay */
-/*    $('#top-menu .right-nav .login-link').on('click', function(event) {
+    $('#top-menu .right-nav .login-link').on('click', function(event) {
         $('#login-overlay').toggle();
         if ($('#login-overlay').is(':visible')) {
             $('#login-overlay input[name="email"]').focus();
         }
     });
-*/
+
     $('.login-form').on('submit', function(event) {
         if ($(this).hasClass("login-form-page")) {
             form_origin_position = "login-page";

--- a/funsite/static/funsite/js/header.js
+++ b/funsite/static/funsite/js/header.js
@@ -65,4 +65,16 @@
         // aria-haspopup is used to improve accessibility.
         $('#top-menu .right-nav .toggle-dropdown-menu').attr('aria-haspopup', display);
     }
+
+    /* Fill csrf token in forms that require it. For forms included in pages
+     * cached in anonymous mode, the csrf_token variable is not usable. */
+    var csrfToken = checkCookie('csrftoken');
+    var forms = $("form.missing-csrf");
+    if (forms.length > 0) {
+        if (csrfToken) {
+            forms.append("<input type='hidden' name='csrfmiddlewaretoken' style='display: none;' value='" + csrfToken + "'/>");
+        } else {
+            console.error("Missing CSRF token. Forms will not be submitted properly.");
+        }
+    }
  })();

--- a/funsite/templates/funsite/parts/base.html
+++ b/funsite/templates/funsite/parts/base.html
@@ -41,8 +41,6 @@ dir_rtl = 'rtl' if get_language_bidi() else 'ltr'
       <script src="//oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
       <script src="//oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
-    <style>
-    </style>
 
     <%include file="/google_analytics.html" />
   </head>
@@ -84,8 +82,8 @@ dir_rtl = 'rtl' if get_language_bidi() else 'ltr'
     <script type="text/javascript" src="/jsi18n/"></script>
     <script type="text/javascript" src="${staticfiles_storage.url('js/src/utility.js')}"></script>
     <script type="text/javascript" src="${staticfiles_storage.url('funsite/js/fun.js')}"></script>
-    <script type="text/javascript" src="${staticfiles_storage.url('funsite/js/header.js')}"></script>
     <script type="text/javascript" src="${staticfiles_storage.url('fun/js/cookie-banner.js')}"></script>
+    <script type="text/javascript" src="${staticfiles_storage.url('funsite/js/header.js')}"></script>
     <%block name="js_extra"/>
   </body>
 </html>

--- a/funsite/templates/funsite/parts/login-overlay.html
+++ b/funsite/templates/funsite/parts/login-overlay.html
@@ -11,33 +11,27 @@ from django.utils.translation import ugettext as _
         <div class="parts">
             <h3>${_(u"You have an account")}</h3>
         </div>
-        <form role="form" class="login-form" method="post" data-remote="true" action="/login_ajax" novalidate>
-           <div style="display:none">
-              <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }"/>
-           </div>
-
+        <form role="form" class="login-form missing-csrf" method="post" data-remote="true" action="/login_ajax" novalidate>
             <div class="parts">
                 <input name="email" type="text" placeholder="${_(u"Email")}"><br>
             </div>
             <div class="parts">
                 <input name="password" type="password" placeholder="${_(u"Password")}"><br>
             </div>
-        <div class="parts forgotten-password">
-            <a data-keyboard="true" data-toggle="modal" data-target="#modal-forget-password" ref="">${_(u"Forgotten password ?")}</a>
-        </div>
-        <div class="parts error">
+            <div class="parts forgotten-password">
+                <a data-keyboard="true" data-toggle="modal" data-target="#modal-forget-password" ref="">${_(u"Forgotten password ?")}</a>
+            </div>
+            <div class="parts error"></div>
 
-        </div>
-
-        <div class="parts">
-            <button name="submit" type="submit" id="submit" class="bottom-margin btn btn-primary btn-padded btn-block" aria-disabled="false">${_(u"Login")}</button>
-        </div>
-        <div class="parts">
-            <h3>${_(u"You don't have an account")}</h3>
-        </div>
-        <div class="parts">
-            <a class="btn btn-default btn-padded btn-block" href="${reverse('register_user')}">${_(u"Create an account")}</a>
-        </div>
+            <div class="parts">
+                <button name="submit" type="submit" id="submit" class="bottom-margin btn btn-primary btn-padded btn-block" aria-disabled="false">${_(u"Login")}</button>
+            </div>
+            <div class="parts">
+                <h3>${_(u"You don't have an account")}</h3>
+            </div>
+            <div class="parts">
+                <a class="btn btn-default btn-padded btn-block" href="${reverse('register_user')}">${_(u"Create an account")}</a>
+            </div>
         </form>
     </div>
 </div>

--- a/funsite/templates/funsite/parts/menu.html
+++ b/funsite/templates/funsite/parts/menu.html
@@ -50,7 +50,7 @@ from staticfiles.storage import staticfiles_storage
             </ul>
         % else:
             <a class="nav-link-block signup-link" href="${reverse('register_user')}"><span>${_(u"Sign up")}</span></a>
-            <a class="nav-link-block login-link" href="${reverse('signin_user')}">
+            <a class="nav-link-block login-link" href="${'#' if base_application == 'funsite' else reverse('signin_user')}">
                 <img class="user-icon" src="${staticfiles_storage.url('funsite/images/icones/user.png')}" alt="User icon">
                 <span>${_(u"Login")}</span>
             </a>


### PR DESCRIPTION
The modal login was broken because POST requests did not include
matching csrfmiddlewaretoken parameter and csrftoken cookie value. This
was because some pages (including the landing page) were cached in
anonymous mode.

The problem can be reproduced locally by the following steps:
1) Enable the edx cache in common/djangoapps/util/cache.py
2) Load the landing page in log-out mode
3) Modify the csrftoken cookie value
4) Reload the landing page quickly (before 3 minutes): the
csrfmiddlewaretoken hidden field will have the former value.

We fix this problem by reading the csrftoken cookie at
runtime in javascript.

This closes issue #2173.