### PR TITLE
Remove reference to djpyfs

### DIFF
--- a/fun/envs/dev.py
+++ b/fun/envs/dev.py
@@ -33,7 +33,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 ################################ DEBUG TOOLBAR ################################
 
-DEBUG_TOOLBAR_INSTALLED_APPS = ('debug_toolbar', 'djpyfs',)
+DEBUG_TOOLBAR_INSTALLED_APPS = ('debug_toolbar',)
 DEBUG_TOOLBAR_MIDDLEWARE_CLASSES = (
     'django_comment_client.utils.QueryCountDebugMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',


### PR DESCRIPTION
django-pyfs is a module that adds S3-like API to the local filesystem.
It was mistakenly added to our dev installed apps as a Django debug
toolbar app, but it is in fact used nowhere. Proof of that is that the
syncdb command fails because of djpyfs, thus SQL tables are never
created for this app. To reproduce the bug, run the following command
before and after applying this patch:

        fun lms.dev syncdb # fails before, succeeds after.