### PR TITLE
Course detail: Display first university when course is made by several

### DIFF
--- a/funsite/templates/lms/courseware/course_about.html
+++ b/funsite/templates/lms/courseware/course_about.html
@@ -151,13 +151,13 @@ from fun.utils import get_fun_course, get_teaser, registration_datetime_text
 
 
                 <div class="course-about-university-logo">
-                    % if fun_course.universities.exists():
-                        % if fun_course.universities.all()[0].detail_page_enabled:
-                            <a href="${fun_course.universities.all()[0].get_absolute_url()}">
-                                <img src="${ fun_course.universities.all()[0].get_logo_thumbnail()}">
+                    % if fun_course.first_university:
+                        % if fun_course.first_university.detail_page_enabled:
+                            <a href="${fun_course.first_university.get_absolute_url()}">
+                                <img src="${fun_course.first_university.get_logo_thumbnail()}">
                             </a>
                         % else:
-                            <img src="${ fun_course.universities.all()[0].get_logo_thumbnail()}">
+                            <img src="${fun_course.first_university.get_logo_thumbnail()}">
                         % endif
                     % endif
                 </div>


### PR DESCRIPTION
When course is created by several universities, one can order university importance in Django admin to display the main one. This modification ensure the first one is displayed on course detail page, ie. the one with the lower order value

closes #2214