### PR TITLE
CSS trick to allow retina logo for hi res screen and IE compatibility

### DIFF
--- a/funsite/static/funsite/css/header.css
+++ b/funsite/static/funsite/css/header.css
@@ -41,6 +41,21 @@
     font-family: 'Raleway', sans-serif;
 }
 
+#top-menu span.fun-logo {
+    background-image: url('../images/logos/fun61.png');
+    background-size: 61px 58px;
+    width: 61px;
+    height: 58px;
+    display: inline-block;
+    vertical-align: middle;
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+    #top-menu span.fun-logo {
+        background-image: url('../images/logos/fun195.png');
+    }
+}
+
+
 .slogan, .username {
     font-family: 'Raleway', sans-serif;
 }

--- a/funsite/templates/funsite/parts/menu.html
+++ b/funsite/templates/funsite/parts/menu.html
@@ -30,7 +30,6 @@ from staticfiles.storage import staticfiles_storage
             <span></span>
             <span></span>
         </div>
-        <a href="${reverse('root')}">
             <img class="logo" src="${staticfiles_storage.url(settings.FUN_SMALL_LOGO_RELATIVE_PATH)}" alt="Logo FUN">
         </a>
         <span class="slogan">${_(u"The Freedom to Study")}</span>


### PR DESCRIPTION
For what ever reason in 2015 Internet explorer is not yet able to automaticaly resize a PNG with correct antialiasing. It force us to have 2 versions of FUN logo and a mediaquery to choose the good one regarding screen density

Should close #2033

WIP