### PR TITLE
Restore mistakenly removed funsite stylesheets

### DIFF
--- a/funsite/templates/funsite/parts/base.html
+++ b/funsite/templates/funsite/parts/base.html
@@ -27,7 +27,10 @@ dir_rtl = 'rtl' if get_language_bidi() else 'ltr'
     <link rel="icon" type="image/x-icon" href="${staticfiles_storage.url(microsite.get_value('favicon_path', settings.FAVICON_PATH))}" />
     <link href="${staticfiles_storage.url('funsite/bootstrap/css/bootstrap.min.css')}" rel="stylesheet">
     <link rel="stylesheet" href="${staticfiles_storage.url('funsite/owl.carousel/assets/owl.carousel.css')}">
+    <link href="${staticfiles_storage.url('fun/css/cookie-banner.css')}" rel="stylesheet">
+    <link href="${staticfiles_storage.url('funsite/css/header.css')}" rel="stylesheet">
     <link href="${staticfiles_storage.url('funsite/css/fun.css')}" rel="stylesheet">
+    <link href="${staticfiles_storage.url('funsite/css/footer.css')}" rel="stylesheet">
     <%block name="css_extra" />
 
     <title>FUN - <%block name="title" /></title>


### PR DESCRIPTION
Header, footer and cookie banner had been incorrectly removed in
5fba040c.