### PR TITLE
Remove flex properties in navigation-bar which is not handled by all browsers

### DIFF
--- a/funsite/static/funsite/css/fun.css
+++ b/funsite/static/funsite/css/fun.css
@@ -1237,24 +1237,7 @@ ul.universities-list {
 /**** Navigation bar ****/
 
 .navigation-bar {
-    display: -webkit-flex;
-    display: -webkit-box;
-    display: -moz-box;
-    display: -ms-flexbox;
-    display: flex;
-
-    -webkit-justify-content:  space-between;
-    -webkit-box-justify-content: space-between;
-    -moz-box-justify-content:  space-between;
-    -ms-justify-content:  space-between;
-    justify-content: space-between;
-
-    -webkit-flex-wrap:  wrap;
-    -webkit-box-flex-wrap: wrap;
-    -moz-box-flex-wrap:  wrap;
-    -ms-flex-wrap:  wrap;
-    flex-wrap: wrap;
-
+    position:relative;
     padding-left: 20px;
     margin-bottom: 24px;
     border: 1px solid #CBCCCD;
@@ -1277,6 +1260,11 @@ ul.universities-list {
 }
 .navigation-block .pages {
     display: inline-block;
+}
+.navigation-right {
+    position: absolute;
+    top: 0;
+    right: 0;
 }
 
 


### PR DESCRIPTION
This flex properties were only used to align the pagination menu inside
the navigation bar to the right.
We can achieve this only by using using the css `position` class.

Ticket https://fun.plan.io/issues/2226