### PR TITLE
Remove contact form and invite user to send an email.

### DIFF
--- a/contact/templates/contact/contact_form.html
+++ b/contact/templates/contact/contact_form.html
@@ -17,35 +17,15 @@ from django.core.urlresolvers import reverse
 ${breadcrumbs.breadcrumbs(_("Contact"))}
 <div class="single-column">
     <h2>${_('Contact us')}</h2>
-    <p>${_("Do you already follow one or several courses on {platform_name}? If you have questions, suggestions or difficulties about a course in particular? Post a comment on the related forum.").format(platform_name=settings.PLATFORM_NAME)}</p>
+    <br><br>
+    <p>
+    Pour nous contacter, merci de bien vouloir écrire à l'adresse <a href="mailto:contact@france-universite-numerique-mooc.fr">contact@france-universite-numerique-mooc.fr</a> en indiquant en plus de votre message, vos <strong>nom, prénom, numéro de téléphone, et fonction</strong>.
+    <br><br>
+    Le support technique FUN vous repondra le plus rapidement possible.
 
-    <p>${_("Do you have a general question about {platform_name}? Visit our <a href='{faq_link}'>FAQ</a>. If you still need help, or if you would like to provide feedback about {platform_name} (which we encourage you to do), contact us using the form below.").format(platform_name=settings.PLATFORM_NAME, faq_link=reverse('faq:index'))}</p>
+    </p>
 
-    <form action="#contact-form" method="post" onsubmit="document.getElementById('send_button').disabled = 1;" novalidate>
-        % if form.errors:
-        <div role="alert" class="alert alert-danger status message is-shown">
-            <p><strong>${_('The following errors are preventing the message from being sent:')}</strong></p>
-            <ul>
-                ${form.non_field_errors()}
-                % for field in form:
-                    % if field.errors:
-                      <li>${field.label} : ${striptags(field.errors).lower()}</li>
-                    % endif
-                % endfor
-          </ul>
-        </div>
-        % endif
-        <div style="display:none">
-            <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
-        </div>
-        % for field in form.sorted_fields():
-        <div class="form-group ${'required' if field.field.required else ''}">
-                ${field.label_tag()}
-                ${field}
-            </div>
-        % endfor
-        <button id='send_button' name="submit" type="submit" class="btn btn-block btn-lg btn-primary">${_("Send your message")}</button>
-        <p><label class="required"></label> ${_("Mandatory field")}</p>
-    </form>
+    <br><br><br><br><br><br>
+
 </div>
 </%block>


### PR DESCRIPTION
For quality and security Mailjet service requests validation of email sender before allowing traffic, but we need technical support emails to have requester address as sender for correct handling by Zendesk.
While the problem should be fixed by configuring Postfix to not use Mailjet for emails sent to contact@france-universit-numerique-mooc.fr, this commit is a quickfix to stop losing user requests.

This commit should be reversed in a while.