### PR TITLE
Include login icon to login link area.

### DIFF
--- a/funsite/static/funsite/css/header.css
+++ b/funsite/static/funsite/css/header.css
@@ -233,7 +233,7 @@ a.no-decoration:visited {
     #top-menu .left-header .course-org,
     #top-menu .left-header .course-display-name,
     #top-menu .right-header .signup-link,
-    #top-menu .right-header .login-link  
+    #top-menu .right-header .login-label  
     {
 	display: none;
     }

--- a/funsite/templates/funsite/parts/menu.html
+++ b/funsite/templates/funsite/parts/menu.html
@@ -45,10 +45,8 @@ from staticfiles.storage import staticfiles_storage
             <a class="signup-link header-block" href="${reverse('register_user')}">
                 <span class="color-fun-red heavy-weight">${_(u"Sign up")}</span>
             </a>
-            <a class="user-icon-sign-in-link header-block" href="">
-                <img class="user-icon" src="${staticfiles_storage.url('funsite/images/icones/user.png')}" alt="User icon">
-            </a>
             <a class="login-link header-block" href="${'#' if base_application == 'funsite' else reverse('signin_user')}">
+                <img class="user-icon" src="${staticfiles_storage.url('funsite/images/icones/user.png')}" alt="User icon">
                 <span class="login-label color-fun-white heavy-weight">${_(u"Login")}</span>
             </a>
         % else:


### PR DESCRIPTION
The login overlay is triggered by clicking on .login-link class
element (see fun-apps/funsite/static/funsite/js/fun.js).
The overlay couldn't show up because the icon was not included in this area.