### PR TITLE
Fix video teaser issue in Firefox

### DIFF
--- a/funsite/templates/lms/courseware/course_about.html
+++ b/funsite/templates/lms/courseware/course_about.html
@@ -338,7 +338,7 @@ from fun.utils import get_fun_course, get_teaser, registration_datetime_text
 
 <!-- Modal -->
 <div class="modal fade" id="video-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-    <div class="modal-dialog" role="document">
+    <div class="modal-dialog" role="document" style="transform: none;">
         <div class="modal-content">
             <div class="inner-wrapper"></div>
         </div>


### PR DESCRIPTION
Video teaser does not show up in Firefox. As investigated by
univ-lorraine, this is due to the fact that the video modal dialog
appears with a "transform: translation(i0px, 0px)" css rule. Solution
was found here: http://stackoverflow.com/questions/20796646/video-not-working-in-bootstrap-modal-pop-up-on-firefox
(Note that we don't have the true explanation, though)

This closes issue #2178.