### PR TITLE
Prevent Vertical scrollbar from being displayed over site content on …

### DIFF
--- a/funsite/static/funsite/css/fun.css
+++ b/funsite/static/funsite/css/fun.css
@@ -3,6 +3,7 @@
 body {
     background-color: #edeeef;
     font-family: 'Raleway', sans-serif;
+    -ms-overflow-style: scrollbar;
 }
 
 .main-width {
@@ -1175,7 +1176,7 @@ ul.universities-list {
     display: -webkit-flex;
     display: -ms-flex;
     display: -moz-flex;
-    width: 100%;
+    width: 99%;
 }
 
 .course-list-table .left {


### PR DESCRIPTION
…Internet Explorer

This behavior is caused by Boostrap
See http://stackoverflow.com/questions/1336600/css-only-horizontal-overflow

Closes #2150