### PR TITLE
Take accented characters into account for sorting universities

### DIFF
--- a/course_pages/templates/course_pages/index.html
+++ b/course_pages/templates/course_pages/index.html
@@ -222,8 +222,10 @@ require(["jquery", "underscore", "backbone"],
                 // Insert view at the proper position, sorted by title
                 var view = this.createView(item);
                 var insertBeforeIndex;
+                var itemTitle = item.get('title');
                 for (insertBeforeIndex=0; insertBeforeIndex < this.sortedViews.length; insertBeforeIndex++) {
-                  if (this.viewTitle(insertBeforeIndex) > item.get('title')) {
+                  // We use locale-sensitive string comparison to make sure accented titles are correctly sorted
+                  if (itemTitle.localeCompare(this.viewTitle(insertBeforeIndex)) < 0) {
                       break;
                   }
                 }


### PR DESCRIPTION
University names are displayed in alphabetical order in the "All
universities" button from the /cours page. Same for themes. Accented
characters were not being taken into account in the sort. This is
resolved by using the localeCompare javascript function.

This closes issue #2213.