### PR TITLE
Iterate page-by-page on libcast resources

### DIFF
--- a/videoproviders/api/base.py
+++ b/videoproviders/api/base.py
@@ -84,8 +84,8 @@ class BaseClient(object):
         except KeyError:
             raise ClientError("Error in uploading file")
 
-    def get(self, endpoint, params=None):
-        return self.request(endpoint, params=params)
+    def get(self, endpoint, params=None, headers=None):
+        return self.request(endpoint, params=params, headers=headers)
 
     def post(self, endpoint, params=None, files=None):
         return self.request(endpoint, method='POST', params=params, files=files)
@@ -96,8 +96,8 @@ class BaseClient(object):
     def delete(self, endpoint, params=None):
         return self.request(endpoint, method='DELETE', params=params)
 
-    def safe_get(self, endpoint, params=None, message=''):
-        return self.safe_request(endpoint, params=params, message=message)
+    def safe_get(self, endpoint, params=None, message='', headers=None):
+        return self.safe_request(endpoint, params=params, message=message, headers=headers)
 
     def safe_post(self, endpoint, params=None, files=None, message=''):
         return self.safe_request(endpoint, method='POST', params=params, files=files, message=message)
@@ -109,8 +109,8 @@ class BaseClient(object):
         return self.safe_request(endpoint, method='DELETE', params=params, message=message)
 
     # pylint: disable=too-many-arguments
-    def safe_request(self, endpoint, method='GET', params=None, files=None, message=''):
-        response = self.request(endpoint, method=method, params=params, files=files)
+    def safe_request(self, endpoint, method='GET', params=None, files=None, message='', headers=None):
+        response = self.request(endpoint, method=method, params=params, files=files, headers=headers)
         if response.status_code >= 400:
             raise ClientError(message)
         return response
@@ -119,7 +119,7 @@ class BaseClient(object):
     # Methods to implement start here
     #################################
 
-    def request(self, endpoint, method='GET', params=None, files=None):
+    def request(self, endpoint, method='GET', params=None, files=None, headers=None):
         raise NotImplementedError()
 
     def get_auth(self):


### PR DESCRIPTION
The libcast API may take a long time to respond to resource listing
requests. When there are many resources, the time required may be longer
than the tolerated timeout. To overcome this issue, we iterate page by
page on the libcast resources. This increases the rendering time of
the video upload dashboard but reduces the probability of timeouts.

This is related to issue #2046.