### PR TITLE
Add a celery error test in selftest application.

### DIFF
--- a/selftest/tasks.py
+++ b/selftest/tasks.py
@@ -1,0 +1,5 @@
+from celery import task
+
+@task
+def trigger_worker_error():
+    raise Exception("This is an intentional 500 triggered in a celery task.")

--- a/selftest/templates/selftest/index.html
+++ b/selftest/templates/selftest/index.html
@@ -51,6 +51,7 @@
 <tr><th colspan="2">Liens</th></tr>
 <tr><td>404</td><td><a href="{% url 'self-test-404' %}">404</a></td></tr>
 <tr><td>500</td><td><a href="{% url 'self-test-500' %}">500</a></td></tr>
+<tr><td>Worker error</td><td><a href="{% url 'worker-error' %}">500</a></td></tr>
 
 
 <tr><th colspan="2">Email</th></tr>

--- a/selftest/urls.py
+++ b/selftest/urls.py
@@ -7,4 +7,5 @@ urlpatterns = patterns('selftest.views',
     url(r'^$', 'selftest_index', name='self-test-index'),
     url(r'^page_not_found/$', 'page_not_found', name='self-test-404'),
     url(r'^server_error/$', 'server_error', name='self-test-500'),
+    url(r'^worker_error/$', 'worker_error', name='worker-error')
 )

--- a/selftest/views.py
+++ b/selftest/views.py
@@ -17,6 +17,7 @@ from django.views.debug import get_safe_settings
 from dealer.git import git
 
 from .forms import EmailForm
+from selftest.tasks import trigger_worker_error
 
 
 repositories = ['edx-platform', 'fun-config', 'fun-apps',
@@ -76,3 +77,10 @@ def server_error(request):
     if not request.user.is_superuser:
         raise Http404
     raise Exception("This is an intentional 500 (server error).")
+
+def worker_error(request):
+    task = trigger_worker_error.apply_async()
+    messages.add_message(request, messages.INFO, "Request sent. Task id: {}".format(task.id))
+    return HttpResponseRedirect(reverse('self-test-index'))
+
+


### PR DESCRIPTION
New button to trigger a 500 error in a celery task.
This can help us knowing if we correctly log workers error in sentry.

Ticket https://fun.plan.io/issues/2236