### PR TITLE
Add course specific user ids in problem stats reports.

### DIFF
--- a/course_dashboard/reports_manager/tasks.py
+++ b/course_dashboard/reports_manager/tasks.py
@@ -3,7 +3,7 @@ import json
 from time import time
 
 from courseware.models import StudentModule
-from student.models import UserProfile
+from student.models import UserProfile, anonymous_id_for_user
 from instructor_task.tasks_helper import TaskProgress
 from xmodule.modulestore.django import modulestore
 
@@ -35,7 +35,7 @@ def create_header_row(problem_size):
     """
     Return the csv header row as list.
     """
-    header_row = ['id', 'gender', 'year_of_birth', 'level_of_education']
+    header_row = ['id', 'course_specific_id', 'gender', 'year_of_birth', 'level_of_education']
     header_row += ['q' + str(i) for i in range(1, problem_size + 1)]
     return header_row
 
@@ -46,6 +46,7 @@ def fetch_user_profile_data(student_module):
     user = student_module.student
     user_profile = UserProfile.objects.get(user=user)
     data_row = [anonymize_username(user.username),
+                anonymous_id_for_user(user, student_module.course_id),
                 unicode(user_profile.gender),
                 unicode(user_profile.year_of_birth),
                 unicode(user_profile.level_of_education)]

--- a/course_dashboard/reports_manager/tests/test_tasks.py
+++ b/course_dashboard/reports_manager/tests/test_tasks.py
@@ -8,7 +8,7 @@ from mock import patch
 from django.conf import settings
 from django.test.utils import override_settings
 
-from student.models import UserProfile
+from student.models import UserProfile, anonymous_id_for_user
 from student.tests.factories import UserFactory
 from courseware.tests.factories import StudentModuleFactory
 from instructor_task.tests.test_base import InstructorTaskModuleTestCase, OPTION_1, OPTION_2
@@ -66,6 +66,7 @@ class AnswersDistributionReportsTask(InstructorTaskModuleTestCase, ProblemMonito
     def _create_response_row(self):
         user_profile = UserProfile.objects.get(user__username=self.username)
         response_row = [unicode(x) for x in [anonymize_username(user_profile.user.username),
+                                             anonymous_id_for_user(user_profile.user, self.course.id),
                                              user_profile.gender, user_profile.year_of_birth,
                                              user_profile.level_of_education]] + [OPTION_1, OPTION_2]
         return response_row
@@ -77,7 +78,7 @@ class AnswersDistributionReportsTask(InstructorTaskModuleTestCase, ProblemMonito
         rows = self._read_report_file(get_path(self.running_report_name,
                                                self.problem_module.location))
 
-        self.assertEqual(rows[1], ['id', 'gender', 'year_of_birth', 'level_of_education',
+        self.assertEqual(rows[1], ['id', 'course_specific_id', 'gender', 'year_of_birth', 'level_of_education',
                                    'q1', 'q2'])
 
         response_row = self._create_response_row()


### PR DESCRIPTION
Ajout de la colonne "Course Specific Anonymized User ID" dans le rapport de note du course_dashboard.
This closes issue https://fun.plan.io/issues/2382