### PR TITLE
Fix news article created_at date in backoffice form

### DIFF
--- a/backoffice/forms.py
+++ b/backoffice/forms.py
@@ -43,11 +43,17 @@ class UserProfileForm(forms.ModelForm):
 
 
 class ArticleForm(forms.ModelForm):
+    # Make sure that the datetime formats used for form rendering and JS parsing are the same.
+    DATETIME_INPUT_FORMAT = '%d/%m/%Y %H:%M'
+    DATETIME_INPUT_FORMAT_JS = 'DD/MM/YYYY HH:mm'
+    created_at = forms.DateTimeField(
+        input_formats=(DATETIME_INPUT_FORMAT,),
+        widget=forms.DateTimeInput(format=DATETIME_INPUT_FORMAT),
+    )
 
     class Meta:
         model = Article
-        fields = ['title', 'slug', 'created_at', 'thumbnail', 'language',
-                'text', 'published',]
+        fields = ['title', 'slug', 'created_at', 'thumbnail', 'language', 'text', 'published',]
 
     def save(self, *args, **kwargs):
         if settings.FEATURES['USE_MICROSITES']:

--- a/backoffice/templates/backoffice/article.html
+++ b/backoffice/templates/backoffice/article.html
@@ -19,7 +19,7 @@
     <script>
     $(function () {
         // Use bootstrap plugin for 'created_at' field
-        $('#id_created_at').datetimepicker({format: 'MM/DD/YYYY HH:mm'});
+        $('#id_created_at').datetimepicker({format: '{{ form.DATETIME_INPUT_FORMAT_JS }}'});
 
         // handle slug generation from title
         document.getElementById("id_title").onkeyup = function() {

--- a/backoffice/tests/test_microsites.py
+++ b/backoffice/tests/test_microsites.py
@@ -91,7 +91,7 @@ class TestMicrositeUsers(BaseMicrositeTestCase):
             'slug': 'admin_microsite1',
             'published': True,
             'language': 'fr',
-            'created_at': '24/07/2015 12:46:20',
+            'created_at': '24/07/2015 12:46',
             'text': 'blah',
         }
         self.client.login(username=self.backuser1.username, password='password')


### PR DESCRIPTION
The created_at field needs to have a formatted recognized by the
javascript datetime parsing library. This format needs to be the same
for all languages, in particular when the logged-in user has selected
the French language. Thus, we need to specify the behaviour of both the
form field and the form widget.

This addresses (partially) issue #2316.