### PR TITLE
Add funsite templates directory to Django templates finder.

### DIFF
--- a/fun/envs/lms/common.py
+++ b/fun/envs/lms/common.py
@@ -103,6 +103,9 @@ MAKO_TEMPLATES['main'] = [
     FUN_BASE_ROOT / 'newsfeed/templates',
 ] + MAKO_TEMPLATES['main']
 
+# Add funsite templates directory to Django templates finder.
+TEMPLATE_DIRS.insert(0, FUN_BASE_ROOT / 'funsite/templates/lms')
+
 # Xiti
 XITI_ENABLED = True
 XITI_XTN2 = '100'


### PR DESCRIPTION
"fun-apps/funsite/templates/lms/navigation.html" a MAKO template is
called from a DJANGO template (edx-platform/lms/templates/main_django.html)
that why we need to add the funsite/lms templates directory to the Django setting `TEMPLATE_DIRS`.

This closes issue https://fun.plan.io/issues/2392.