### PR TITLE
Add university full name in header

### DIFF
--- a/backoffice/forms.py
+++ b/backoffice/forms.py
@@ -43,11 +43,17 @@ class UserProfileForm(forms.ModelForm):
 
 
 class ArticleForm(forms.ModelForm):
+    # Make sure that the datetime formats used for form rendering and JS parsing are the same.
+    DATETIME_INPUT_FORMAT = '%d/%m/%Y %H:%M'
+    DATETIME_INPUT_FORMAT_JS = 'DD/MM/YYYY HH:mm'
+    created_at = forms.DateTimeField(
+        input_formats=(DATETIME_INPUT_FORMAT,),
+        widget=forms.DateTimeInput(format=DATETIME_INPUT_FORMAT),
+    )
 
     class Meta:
         model = Article
-        fields = ['title', 'slug', 'created_at', 'thumbnail', 'language',
-                'text', 'published',]
+        fields = ['title', 'slug', 'created_at', 'thumbnail', 'language', 'text', 'published',]
 
     def save(self, *args, **kwargs):
         if settings.FEATURES['USE_MICROSITES']:

--- a/backoffice/templates/backoffice/article.html
+++ b/backoffice/templates/backoffice/article.html
@@ -19,7 +19,7 @@
     <script>
     $(function () {
         // Use bootstrap plugin for 'created_at' field
-        $('#id_created_at').datetimepicker({format: 'MM/DD/YYYY HH:mm'});
+        $('#id_created_at').datetimepicker({format: '{{ form.DATETIME_INPUT_FORMAT_JS }}'});
 
         // handle slug generation from title
         document.getElementById("id_title").onkeyup = function() {

--- a/backoffice/tests/test_microsites.py
+++ b/backoffice/tests/test_microsites.py
@@ -91,7 +91,7 @@ class TestMicrositeUsers(BaseMicrositeTestCase):
             'slug': 'admin_microsite1',
             'published': True,
             'language': 'fr',
-            'created_at': '24/07/2015 12:46:20',
+            'created_at': '24/07/2015 12:46',
             'text': 'blah',
         }
         self.client.login(username=self.backuser1.username, password='password')

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 # Changelog www.france-universite-numerique.fr
 
+## 3.2
+- Backoffice: Page de gestion du wiki
+    + Affichage de l'arborescence des pages et leur activité
+    + Retrait et ajout des permissions d'écriture
+- Amélioration de la gestion des actualités dans le backoffice et de leur ordre d'affichage sur le front
+- SEO: Amélioration des `title` et `meta description` de la home page
+- Prise en compte des majuscules accentuées dans le tri des établisement et thématiques
+- Amelioration du support Internet Explorer
+
 ## 3.1 8/12/2015
 - Possibilité de spécifier la langues principale d'un cours
     - Création des certificats dans cette langue

--- a/course_pages/tests/test_pages.py
+++ b/course_pages/tests/test_pages.py
@@ -3,6 +3,10 @@
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
+from courses.models import Course
+from courses.choices import COURSE_LANGUAGES
+from courses.utils import get_courses_per_language
+
 from fun.tests.utils import skipUnlessLms
 
 
@@ -17,3 +21,35 @@ class CourseListTest(TestCase):
     def test_filter_url(self):
         url = reverse('fun-courses:filter', kwargs={'subject': 'physics'})
         self.assertEqual("/cours/#filter/subject/physics", url)
+
+
+@skipUnlessLms
+class CourseLanguagesTest(TestCase):
+    def setUp(self):
+        Course.objects.create(key='1', language='fr', is_active=True)
+        Course.objects.create(key='2', language='en', is_active=True)
+        Course.objects.create(key='3', language='', is_active=True)  # this should no happen but do
+        Course.objects.create(key='4', language='cn', is_active=True)  # this language is not present in courses.choices.COURSE_LANGUAGES
+
+    def test_course_list_page_loads(self):
+        """Ensure /cours view do not crash when bad data is present in bdd."""
+        url = reverse('fun-courses:index')
+        response = self.client.get(url)
+        self.assertContains(response, 'courses')
+
+    def test_available_languages(self):
+        """Ensure only available languages are returned by get_courses_per_language()."""
+        languages = get_courses_per_language()
+        self.assertEqual(len(COURSE_LANGUAGES), len(languages))
+        self.assertEqual(
+            set([c[0] for c in COURSE_LANGUAGES]),
+            set([c['language'] for c in languages])
+            )
+
+    def test_get_available_languages_structure(self):
+        """Ensure get_courses_per_language() returns correct dict structure."""
+        languages = get_courses_per_language()
+        self.assertEqual(languages[0]['language'], COURSE_LANGUAGES[0][0])
+        self.assertEqual(languages[0]['count'], 1)
+        self.assertEqual(languages[1]['language'], COURSE_LANGUAGES[1][0])
+        self.assertEqual(languages[1]['count'], 1)

--- a/course_pages/views.py
+++ b/course_pages/views.py
@@ -2,7 +2,6 @@
 
 from django.core.urlresolvers import reverse
 from django.contrib.syndication.views import Feed
-from django.db.models import Count
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 
@@ -22,10 +21,7 @@ def courses_index(request, subject=None):
     Args:
         subject (str): subject slug that allows to reverse course filtering urls.
     """
-    # get course count for distinct languages
-    languages = Course.objects.public().values('language').distinct().annotate(count=Count('id'))
-    # update returned dict with language name comming from courses.choices.COURSE_LANGUAGES
-    languages = [dict(language, title=unicode(dict(COURSE_LANGUAGES)[language['language']])) for language in languages]
+    languages = courses.utils.get_courses_per_language()
     return render_to_response('course_pages/index.html', {
         "course_subjects": annotate_with_public_courses(CourseSubject.objects.by_score()),
         "universities": annotate_with_public_courses(University.objects.active_by_score()),

--- a/courses/choices.py
+++ b/courses/choices.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -12,3 +14,4 @@ COURSE_LEVEL_CHOICES = (
 )
 
 COURSE_LANGUAGES = (('en', _('English')), ('fr', _('French')))
+

--- a/forum_contributors/templates/discussion/_underscore_templates.html
+++ b/forum_contributors/templates/discussion/_underscore_templates.html
@@ -49,7 +49,7 @@
 
 % for template_name in ['thread-show']:
 <script aria-hidden="true" type="text/template" id="${template_name}-template">
-    <%static:include path="js/discussion/${template_name}.underscore" />
+    <%static:include path="common/templates/discussion/${template_name}.underscore" />
 </script>
 % endfor
 

--- a/forum_contributors/views.py
+++ b/forum_contributors/views.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from django_future.csrf import ensure_csrf_cookie
+from django.views.decorators.csrf import ensure_csrf_cookie
 from django.http import HttpResponseBadRequest
 from django.utils.html import strip_tags
 from django.views.decorators.cache import cache_control

--- a/fun/envs/lms/common.py
+++ b/fun/envs/lms/common.py
@@ -103,6 +103,9 @@ MAKO_TEMPLATES['main'] = [
     FUN_BASE_ROOT / 'newsfeed/templates',
 ] + MAKO_TEMPLATES['main']
 
+# Add funsite templates directory to Django templates finder.
+TEMPLATE_DIRS.insert(0, FUN_BASE_ROOT / 'funsite/templates/lms')
+
 # Xiti
 XITI_ENABLED = True
 XITI_XTN2 = '100'

--- a/fun/envs/lms/dev.py
+++ b/fun/envs/lms/dev.py
@@ -27,6 +27,7 @@ FEATURES['AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING'] = True
 FEATURES['ENABLE_PAYMENT_FAKE'] = True
 FEATURES['AUTOMATIC_AUTH_FOR_TESTING'] = True
 
-MAKO_MODULE_DIR = None   # this will prevent Mako to cache generated files
+## MAKO_MODULE_DIR = None   # this will prevent Mako to cache generated files
+
 # To totaly deactivate cache we also have de deactivate edx cache on anonymous views
 # by commenting line 79 (cache.set(cache_key, response, 60 * 3)) in file common/djangoapps/util/cache.py@cache_if_anonymous

--- a/fun_instructor/views.py
+++ b/fun_instructor/views.py
@@ -4,7 +4,7 @@ from util.json_request import JsonResponse
 import urllib
 import os
 
-from django_future.csrf import ensure_csrf_cookie
+from django.views.decorators.csrf import ensure_csrf_cookie
 from django.http import Http404
 from django.views.decorators.cache import cache_control
 from django.http import HttpResponse

--- a/funsite/static/funsite/css/header.css
+++ b/funsite/static/funsite/css/header.css
@@ -189,6 +189,9 @@ a.no-decoration:visited {
 #top-menu .right-header .toggle-dropdown-menu {
     width: 40px;
 }
+#top-menu .vertical-arrow {
+    font-size : 21px;
+}
 #top-menu .right-header .toggle-dropdown-menu:focus {
     outline: 0; /* Override edx focus on `a` tag behaviour. */
 }
@@ -202,6 +205,9 @@ a.no-decoration:visited {
 #top-menu .right-header .user-icon-dashboard-link  {
     display: inline-block;
     padding-top : 15px;
+}
+#top-menu .right-header .toggle-dropdown-menu {
+    padding-top : 12px;
 }
 
 /***** Various light horizontal alignments. *****/

--- a/funsite/templates/funsite/parts/menu.html
+++ b/funsite/templates/funsite/parts/menu.html
@@ -3,6 +3,7 @@
 <%page args="base_application"/>
 
 <%!
+from courses.models import Course
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 from staticfiles.storage import staticfiles_storage
@@ -34,7 +35,14 @@ from staticfiles.storage import staticfiles_storage
             <img class="logo" src="${staticfiles_storage.url(settings.FUN_SMALL_LOGO_RELATIVE_PATH)}" alt="Logo FUN">
         </a>
         % if course:
-            <span class="course-org color-fun-red heavy-weight header-block">${course.display_org_with_default | h}</span>
+            <%
+            try:
+              university_name = Course.objects.get(key=unicode(course.id)).university_name
+              course_org = university_name if university_name else course.display_org_with_default
+            except Course.DoesNotExist:
+              course_org = course.display_org_with_default
+            %>
+            <span class="course-org color-fun-red heavy-weight header-block">${course_org | h}</span>
             <span class="course-display-name color-fun-blue heavy-weight header-block">${course.display_name_with_default | h}</span>
         % else:
             <span class="slogan color-fun-blue heavy-weight header-block">${_(u"The Freedom to Study")}</span>


### PR DESCRIPTION
Afficher dans le header *le nom entier de l'université* au lieu du champ `org` du course_id .
Je pense qu'on peut merger ça sur Cypress.
La feature est présente sur chaloupe pour voir si ça pose problème avec les noms d'université longs.

Ticket https://fun.plan.io/issues/2344.