### PR TITLE
Activation du moteur de recherche Cypress

### DIFF
--- a/fun/envs/cms/common.py
+++ b/fun/envs/cms/common.py
@@ -63,6 +63,10 @@ FEATURES['SUBDOMAIN_BRANDING'] = False
 FEATURES['SUBDOMAIN_COURSE_LISTINGS'] = False
 FEATURES['USE_CUSTOM_THEME'] = False
 
+# index courseware content in 'courseware_index' and course meta information in 'course_info' after every modification in studio
+FEATURES['ENABLE_COURSEWARE_INDEX'] = True
+
+
 CC_PROCESSOR = {
     'CyberSource': {
         'SHARED_SECRET': '',

--- a/fun/envs/common.py
+++ b/fun/envs/common.py
@@ -308,3 +308,5 @@ def configure_raven(sentry_dsn, raven_config, logging_config):
 # FUN Mongo database
 # Other settings FUN_MONGO_HOST, FUN_MONGO_USER and FUN_MONGO_PASSWORD will come from lms/cms.auth.env
 FUN_MONGO_DATABASE = 'fun'
+
+SEARCH_ENGINE = 'search.elastic.ElasticSearchEngine'  # use ES for courseware and course meta information indexing

--- a/fun/envs/lms/common.py
+++ b/fun/envs/lms/common.py
@@ -184,3 +184,6 @@ PIPELINE_CSS['style-main']['source_filenames'].append('forum_contributors/highli
 # js/lms-application.js
 PIPELINE_JS['application']['source_filenames'].append('fun/js/cookie-banner.js')
 PIPELINE_JS['application']['source_filenames'].append('funsite/js/header.js')
+
+FEATURES['ENABLE_DASHBOARD_SEARCH'] = True  # display a search box in student's dashboard to search in courses he is enrolled in.
+FEATURES['ENABLE_COURSE_DISCOVERY'] = False  # display a search box and enable Backbone app on edX's course liste page which we do not use.


### PR DESCRIPTION
       Studio will now index course content and course meta information in ElasticSearch after each modification in studio.
       We enable a searchbox in student's dashboard to allow one to search in course content he is enrolled in.
       However we can not use use backbone application which allow searching in course meta info from course list
       as it's not compatible with our course list page.

Closes #2369 and is related to #2370