### PR TITLE
Course counters - using enrollment end date

### DIFF
--- a/course_pages/templates/course_pages/index.html
+++ b/course_pages/templates/course_pages/index.html
@@ -45,7 +45,7 @@ require(["jquery", "underscore", "backbone"],
 
         var filters = [
             {title: "${_('Availability')}", name: 'availability', type: 'select', select: '#availability-select', values: [
-                {value: 'enrollment-ends-soon', title: "${_('Imminent end of enrollment')}", count: ${courses_count_end_soon}},
+                {value: 'enrollment-ends-soon', title: "${_('Imminent end of enrollment')}", count: ${courses_count_enrollment_ends_soon}},
                 {value: 'start-soon', title: "${_('Starts soon')}", count: ${courses_count_start_soon}},
                 {value: 'new', title: "${_('New')}", count: ${courses_count_new}},
             ]},

--- a/course_pages/views.py
+++ b/course_pages/views.py
@@ -27,7 +27,7 @@ def courses_index(request, subject=None):
         "universities": annotate_with_public_courses(University.objects.active_by_score()),
         "languages": languages,
         "courses_count_start_soon": Course.objects.start_soon().count(),
-        "courses_count_end_soon": Course.objects.end_soon().count(),
+        "courses_count_enrollment_ends_soon": Course.objects.enrollment_ends_soon().count(),
         "courses_count_new": Course.objects.new().count(),
     })
 


### PR DESCRIPTION
There was a confusion on the count of courses. 'End soon' has 2 meanings :  enrollment end date *and* course end date.

- The sidebar filter label was using course end date when displaying the counter.
- The main panel was using enrollment date for listing courses.

This patch fixes the issue - we are now using enrollment end date for both.