### PR TITLE
Fix broken teaser when flash is deactivated

### DIFF
--- a/fun/utils/__init__.py
+++ b/fun/utils/__init__.py
@@ -26,7 +26,7 @@ def get_fun_course(course):
     from courses.models import Course
     return Course.objects.get(key=course.id.to_deprecated_string())
 
-def get_teaser(video_id, autoplay=False, force_html=False):
+def get_teaser(video_id):
     """Build the DailyMotion url from the video_id and return the html snippet.
 
     The teaser will be an HTML5 video that will auto-play.
@@ -47,7 +47,7 @@ def get_teaser(video_id, autoplay=False, force_html=False):
     return (
         '<iframe id="course-teaser" '
         'frameborder="0" scrolling="no" allowfullscreen="" '
-        'src="//www.dailymotion.com/embed/video/{dm_id}/?html&autoplay=1"'
+        'src="//www.dailymotion.com/embed/video/{dm_id}/?html=1&autoplay=1"'
         '></iframe>'
     ).format(dm_id=dm_id)
 


### PR DESCRIPTION
In a browser where flash is deactivated, the dailymotion video of the
course teaser does not play. This is due to the fact that the browser
does not correctly recognize that flash was deactivated. Previously, the
"&html" parameter was recognized by dailymotion, but it's not recognized
anymore. Instead, we need to use the "&html=1" parameter to make sure we
fetch the html5 video.

This should close issue #2515.