### PR TITLE
Fix course search issues

### DIFF
--- a/course_pages/templates/course_pages/index.html
+++ b/course_pages/templates/course_pages/index.html
@@ -530,6 +530,8 @@ require(["jquery", "underscore", "backbone"],
                 });
                 this.listenTo(this.coursecollection, 'sync', this.courseCollectionSynced)
 
+                this.refreshCourseRequest = null;
+
                 Backbone.history.start();
             },
             criterionSelected: function(value) {
@@ -542,7 +544,11 @@ require(["jquery", "underscore", "backbone"],
                     this.coursecollection.pop();
                 }
                 // Fill collection
-                this.coursecollection.fetch();
+                if (this.refreshCourseRequest) {
+                    // Abort previous request
+                    this.refreshCourseRequest.abort();
+                }
+                this.refreshCourseRequest = this.coursecollection.fetch();
                 window.scrollTo(0, 0);
             },
             courseCollectionSynced: function(){

--- a/course_pages/templates/course_pages/index.html
+++ b/course_pages/templates/course_pages/index.html
@@ -74,6 +74,7 @@ require(["jquery", "underscore", "backbone"],
         var AppRouter = Backbone.Router.extend({
             routes: {
                 "(filter)": "initializeFilter",
+                "filter(/:name/:slug)(?page=:page&rpp=:rpp&query=)": "filter",
                 "filter(/:name/:slug)(?page=:page&rpp=:rpp&query=:query)": "filter",
             },
             initialize: function(options) {
@@ -121,9 +122,7 @@ require(["jquery", "underscore", "backbone"],
                 if (page) {
                     this.filter.set("currentPage", parseInt(page));
                 }
-                if (query) {
-                    this.filter.set("query", query);
-                }
+                this.filter.set("query", query);
             },
         });
 

--- a/course_pages/templates/course_pages/index.html
+++ b/course_pages/templates/course_pages/index.html
@@ -366,6 +366,7 @@ require(["jquery", "underscore", "backbone"],
                     this.set({
                         selected: value,
                         currentPage: 1,
+                        query: null,
                     });
                 }
             }


### PR DESCRIPTION
Fix multiple issues with course search:
- Race conditions when typing fast course queries
- Clear query filter when the query field is emptied
- Do not aggregate query filter with other filter, e.g: availability filter.