### PR TITLE
Faster user search in Backoffice

### DIFF
--- a/backoffice/templates/backoffice/users.html
+++ b/backoffice/templates/backoffice/users.html
@@ -40,10 +40,10 @@
     <table class="table table-condensed" id="user-list">
         <thead>
             <tr>
-                <th>{% order_col "profile__name" "Full name" "Full name" %}</th>
-                <th>{% order_col "username" "Username" "Username" %}</th>
-                <th>{% order_col "email" "Email" "Email" %}</th>
-                <th>{% order_col "date_joined" "Account creation date" "Account creation date" %}</th>
+                <th>{% order_col "name" "Full name" "Full name" %}</th>
+                <th>{% order_col "user__username" "Username" "Username" %}</th>
+                <th>{% order_col "user__email" "Email" "Email" %}</th>
+                <th>{% order_col "user__date_joined" "Account creation date" "Account creation date" %}</th>
             </tr>
         </thead>
 

--- a/backoffice/templates/backoffice/users.html
+++ b/backoffice/templates/backoffice/users.html
@@ -49,7 +49,7 @@
 
         {% for user in users.object_list %}
         <tr>
-            <td><a href="{% url 'backoffice:user-detail' user.username %}">{{ user.profile.name|default:"Pas de profile utilsateur" }}</a></td>
+            <td><a href="{% url 'backoffice:user-detail' user.username %}">{{ user.profile.name|default:"Pas de profil utilisateur" }}</a></td>
             <td>{{ user.username }}</td>
             <td>{{ user.email }}</td>
             <td>{{ user.date_joined }}</td>

--- a/backoffice/templates/backoffice/users.html
+++ b/backoffice/templates/backoffice/users.html
@@ -29,12 +29,12 @@
         {{ total_count }} {% trans "users" %}
         <br>
         {% if request.GET.search %}
-            {{ users.paginator.count }} {% trans "results" %}
+            {{ search_results_count }} {% trans "results" %}
         {% endif %}
     </div>
 </div>
 
-{% if users.paginator.count > 0 %}
+{% if search_results_count > 0 %}
 
 <div class="row">
     <table class="table table-condensed" id="user-list">

--- a/backoffice/templates/backoffice/users.html
+++ b/backoffice/templates/backoffice/users.html
@@ -47,12 +47,12 @@
             </tr>
         </thead>
 
-        {% for user in users.object_list %}
+        {% for user_profile in user_profiles.object_list %}
         <tr>
-            <td><a href="{% url 'backoffice:user-detail' user.username %}">{{ user.profile.name|default:"Pas de profil utilisateur" }}</a></td>
-            <td>{{ user.username }}</td>
-            <td>{{ user.email }}</td>
-            <td>{{ user.date_joined }}</td>
+            <td><a href="{% url 'backoffice:user-detail' user_profile.user.username %}">{{ user_profile.name|default:"Pas de profil utilisateur" }}</a></td>
+            <td>{{ user_profile.user.username }}</td>
+            <td>{{ user_profile.user.email }}</td>
+            <td>{{ user_profile.user.date_joined }}</td>
         </tr>
         {% endfor %}
 
@@ -61,7 +61,7 @@
 
 <div class="row">
     <div id="pagination">
-        {{ users.render }}
+        {{ user_profiles.render }}
     </div>
 </div>
 {% else %}

--- a/backoffice/templatetags/tables.py
+++ b/backoffice/templatetags/tables.py
@@ -34,9 +34,9 @@ class OrderTableNode(template.Node):
             if context['request'].GET.get(table_name + 'order') == col_name:
                 css_class = 'colactive'
                 if 'd' in context['request'].GET:
-                    glyph = '<i class="icon-chevron-up"></i>'
+                    glyph = '<i class="glyphicon glyphicon-chevron-up"></i>'
                 else:
-                    glyph = '<i class="icon-chevron-down"></i>'
+                    glyph = '<i class="glyphicon glyphicon-chevron-down"></i>'
 
             if query[table_name + 'order'] == col_name:
                 if table_name + 'd' in query:
@@ -70,10 +70,11 @@ def order_col(parser, token):
 
     """
     try:
-        col_name = token.split_contents()[1]
-        col_title = token.split_contents()[2]
-        tooltip = token.split_contents()[3]
-        table_name = token.split_contents()[4] if len(token.split_contents()) > 4 else ''
+        tokens = token.split_contents()
+        col_name = tokens[1]
+        col_title = tokens[2]
+        tooltip = tokens[3]
+        table_name = tokens[4] if len(tokens) > 4 else ''
 
     except IndexError:
         raise template.TemplateSyntaxError("%r tag requires at least 2 arguments" % token.contents.split()[0])

--- a/backoffice/tests/test_microsites.py
+++ b/backoffice/tests/test_microsites.py
@@ -54,19 +54,19 @@ class TestMicrositeUsers(BaseMicrositeTestCase):
     def test_user_list_with_microsite1(self):
         self.client.login(username=self.backuser1.username, password='password')
         response = self.client.get(reverse('backoffice:user-list'))
-        users = response.context['users'].object_list
-        self.assertTrue(self.user1 in users)
-        self.assertTrue(self.user0 not in users)
-        self.assertTrue(self.user2 not in users)
+        user_profiles = response.context['user_profiles'].object_list
+        self.assertEqual(2, len(user_profiles))
+        self.assertTrue(self.user1.profile in user_profiles)
+        self.assertTrue(self.backuser1.profile in user_profiles)
 
     @setMicrositeTestSettings(FAKE_MICROSITE2)
     def test_user_list_with_microsite2(self):
         self.client.login(username=self.backuser2.username, password='password')
         response = self.client.get(reverse('backoffice:user-list'))
-        users = response.context['users'].object_list
-        self.assertTrue(self.user2 in users)
-        self.assertTrue(self.user0 not in users)
-        self.assertTrue(self.user1 not in users)
+        user_profiles = response.context['user_profiles'].object_list
+        self.assertEqual(2, len(user_profiles))
+        self.assertTrue(self.user2.profile in user_profiles)
+        self.assertTrue(self.backuser2.profile in user_profiles)
 
     @setMicrositeTestSettings(FAKE_MICROSITE1)
     def test_user_edit_with_microsite(self):

--- a/backoffice/tests/test_users.py
+++ b/backoffice/tests/test_users.py
@@ -8,7 +8,7 @@ from django.core.urlresolvers import reverse
 from certificates.models import GeneratedCertificate
 from certificates.tests.factories import GeneratedCertificateFactory
 from student.models import UserStanding, Registration
-from student.tests.factories import UserFactory, CourseEnrollmentFactory, CourseAccessRoleFactory
+from student.tests.factories import UserFactory, UserProfileFactory, CourseEnrollmentFactory, CourseAccessRoleFactory
 
 from fun.tests.utils import skipUnlessLms
 
@@ -26,18 +26,17 @@ class TestUsers(BaseCourseList):
     def test_user_list(self):
         response = self.client.get(reverse('backoffice:user-list'))
         self.assertEqual(200, response.status_code)
-        users = response.context['users'].object_list
-        self.assertTrue(self.user2 in users)
-        self.assertTrue(self.user in users)
-        self.assertTrue(self.user3 not in users)
+        user_profiles = response.context['user_profiles'].object_list
+        self.assertEqual(2, len(user_profiles))
+        self.assertTrue(self.user2.profile in user_profiles)
+        self.assertTrue(self.user.profile in user_profiles)
 
     def test_user_list_filtering(self):
         response = self.client.get(reverse('backoffice:user-list') + '?search=user1')
-        users = response.context['users'].object_list
+        user_profiles = response.context['user_profiles'].object_list
         self.assertEqual(200, response.status_code)
-        self.assertTrue(self.user2 in users)
-        self.assertTrue(self.user3 not in users)
-        self.assertTrue(self.user not in users)
+        self.assertEqual(1, len(user_profiles))
+        self.assertTrue(self.user2.profile in user_profiles)
 
     def test_user_detail(self):
         CourseEnrollmentFactory(course_id=self.course1.id, user=self.user2)

--- a/backoffice/views.py
+++ b/backoffice/views.py
@@ -224,7 +224,7 @@ def course_detail(request, course_key_string):
 
 def order_and_paginate_queryset(request, queryset, default_order):
     order = request.GET.get('order', default_order)
-    direction = '' if 'd' in request.GET else '-'
+    direction = '-' if 'd' in request.GET else ''
     try:
         page = request.GET.get('page', 1)
     except PageNotAnInteger:
@@ -249,7 +249,7 @@ def user_list(request):
             | Q(email__icontains=pattern)
             | Q(profile__name__icontains=pattern)
         )
-    users = order_and_paginate_queryset(request, users, 'date_joined')
+    users = order_and_paginate_queryset(request, users, 'username')
 
     return render(request, 'backoffice/users.html', {
         'users': users,

--- a/backoffice/views.py
+++ b/backoffice/views.py
@@ -253,6 +253,7 @@ def user_list(request):
 
     return render(request, 'backoffice/users.html', {
         'users': users,
+        'search_results_count': users.paginator.count,
         'total_count': total_count,
         'form': form,
         'tab': 'users',

--- a/fun/envs/lms/test.py
+++ b/fun/envs/lms/test.py
@@ -3,6 +3,10 @@ from path import path
 
 ENVIRONMENT = 'test'
 
+############# Disable useless logging
+import logging
+logging.getLogger("backoffice.views").setLevel(logging.ERROR)
+
 ################ Microsite test settings
 
 FAKE_MICROSITE = {


### PR DESCRIPTION
This PR includes multiple fixes (I know, I know...). The most important change is that we query UserProfile objects instead of Users. For some reason I do not understand, this spares us a costly OUTER JOIN.

This closes issue #2483.