### PR TITLE
Group None and 'empty string' countries in course dashboard

### DIFF
--- a/course_dashboard/stats.py
+++ b/course_dashboard/stats.py
@@ -44,16 +44,24 @@ def enrollments_per_day(course_key_string=None, since=None):
             return date
         return datetime.strptime(date, "%Y-%m-%d %H:%M:%S")
 
-    enrollments_per_day = [(dateify(result[period_name]), result['enrollment_count']) for result in query]
-    return add_days_with_no_enrollments(enrollments_per_day)
+    results = [(dateify(result[period_name]), result['enrollment_count']) for result in query]
+    return add_days_with_no_enrollments(results)
 
-def add_days_with_no_enrollments(enrollments_per_day):
-    if not enrollments_per_day:
+def add_days_with_no_enrollments(enrollments):
+    """Fill holes in the enrollments/day stats.
+
+    Args:
+        enrollments: (date, int) list
+
+    Returns:
+        a (date, int) list that contains days for which there were no stats
+    """
+    if not enrollments:
         return []
-    start_day = enrollments_per_day[0][0]
-    result_length = (enrollments_per_day[-1][0] - start_day).days + 1
+    start_day = enrollments[0][0]
+    result_length = (enrollments[-1][0] - start_day).days + 1
     result = [(start_day + timedelta(days=d), 0) for d in xrange(0, result_length)]
-    for day in enrollments_per_day:
+    for day in enrollments:
         index = (day[0] - start_day).days
         result[index] = day
     return result

--- a/course_dashboard/tests/test_stats.py
+++ b/course_dashboard/tests/test_stats.py
@@ -56,6 +56,16 @@ class StatsTestCase(BaseCourseDashboardTestCase):
         self.assertEqual(1, len(course_population))
         self.assertEqual(2, course_population[countries.UNKNOWN_COUNTRY_CODE])
 
+    def test_null_and_empty_countries_are_grouped(self):
+        course = CourseFactory.create()
+        course_id = self.get_course_id(course)
+        CourseEnrollmentFactory.create(course_id=course_id, user__profile__country=None)
+        CourseEnrollmentFactory.create(course_id=course_id, user__profile__country='')
+
+        course_population = stats.population_by_country(course_id)
+        self.assertEqual(1, len(course_population))
+        self.assertEqual(2, course_population[countries.UNKNOWN_COUNTRY_CODE])
+
     def test_dependent_territories_are_not_listed_separately(self):
         course = CourseFactory.create()
         self.enroll_student(course, user__profile__country='GF', user__is_active=False)

--- a/course_dashboard/tests/test_views.py
+++ b/course_dashboard/tests/test_views.py
@@ -5,7 +5,6 @@ from django.utils.translation import ugettext_lazy as _
 
 from student.tests.factories import UserFactory
 
-from fun.utils import countries
 from .base import BaseCourseDashboardTestCase
 
 
@@ -86,10 +85,6 @@ class StudentMapTestCase(BaseCourseDashboardTestCase):
         response = self.get_course_student_map(self.course)
         self.assertEqual(200, response.status_code)
         self.assertIn("France", response.content)
-
-    def test_get_country_name(self):
-        self.assertEqual(_("France"), countries.get_country_name('FR'))
-        self.assertEqual(_("Unknown"), countries.get_country_name(countries.UNKNOWN_COUNTRY_CODE))
 
     def test_student_has_no_access(self):
         student = UserFactory.create()

--- a/fun/utils/countries.py
+++ b/fun/utils/countries.py
@@ -26,7 +26,8 @@ UNKNOWN_COUNTRY_CODE = 'XX'
 
 def territory_country(territory_code):
     """Return the country associated to a territory code."""
-    return TERRITORIES.get(territory_code, territory_code)
+    territory = TERRITORIES.get(territory_code, territory_code)
+    return countries.alpha2(territory) or UNKNOWN_COUNTRY_CODE
 
 def get_country_name(country_code):
     if country_code == UNKNOWN_COUNTRY_CODE:

--- a/fun/utils/tests/test_countries.py
+++ b/fun/utils/tests/test_countries.py
@@ -1,0 +1,18 @@
+from django.test import TestCase
+from django.utils.translation import ugettext as _
+
+from fun.utils import countries
+
+
+class CountriesTests(TestCase):
+
+    def test_get_country_name(self):
+        self.assertEqual(_("France"), countries.get_country_name('FR'))
+        self.assertEqual(_("Unknown"), countries.get_country_name(countries.UNKNOWN_COUNTRY_CODE))
+
+    def test_territory_country(self):
+        self.assertEqual('FR', countries.territory_country('FR'))
+        self.assertEqual('FR', countries.territory_country('GP'))
+        self.assertEqual('NL', countries.territory_country('NL'))
+        # XZ does not exist
+        self.assertEqual(countries.UNKNOWN_COUNTRY_CODE, countries.territory_country('XZ'))


### PR DESCRIPTION
The stats from the unknown country should include the country identified by an empty string.

This closes issue #2480.