### PR TITLE
Do not translate LANGUAGES in the settings

### DIFF
--- a/fun/envs/common.py
+++ b/fun/envs/common.py
@@ -3,7 +3,6 @@
 from glob import glob
 import os
 import sys
-import gettext
 
 from path import path
 
@@ -51,9 +50,9 @@ LANGUAGE_CODE = 'fr'
 # These are the languages we allow on FUN platform
 # DarkLanguageConfig.released_languages must use the same codes (comma separated)
 LANGUAGES = (
-    ('fr', gettext('French')),
-    ('en', gettext('English')),
-    ('de-de', gettext('German')), # codes have to match edX's ones (lms.envs.common.LANGUAGES)
+    ('fr', 'Français'),
+    ('en', 'English'),
+    ('de-de', 'Deutsch'), # codes have to match edX's ones (lms.envs.common.LANGUAGES)
 )
 # EdX rely on this code to display current language to user, when not yet set in preferences
 # This is probably a bug because user with an english browser, will have the english i18n


### PR DESCRIPTION
Since the settings module is executed at the moment the server is run,
and not once per user, it makes no sense to translate the platform
languages in the settings. Instead, the language of each entry in the
"LANGUAGES" variable should appear in the original language of each
entry.

This partially addresses issue #2559.