### PR TITLE
Disable course signals in tests

### DIFF
--- a/backoffice/tests/test.py
+++ b/backoffice/tests/test.py
@@ -7,6 +7,7 @@ from StringIO import StringIO
 
 from django.contrib.auth.models import Group
 from django.core.urlresolvers import reverse
+from django.test.utils import override_settings
 from django.utils.translation import ugettext as _
 
 from lang_pref import LANGUAGE_KEY
@@ -87,6 +88,7 @@ class TestAuthentication(BaseBackoffice):
         self.assertEqual(1, len(response.context['course_infos']))
 
 
+@override_settings(COURSE_SIGNALS_DISABLED=False)
 class TestGenerateCertificate(BaseBackoffice):
     def setUp(self):
         super(TestGenerateCertificate, self).setUp()

--- a/course_pages/tests/test_feed.py
+++ b/course_pages/tests/test_feed.py
@@ -3,6 +3,7 @@
 import datetime
 
 from django.core.urlresolvers import reverse
+from django.test.utils import override_settings
 from django.utils.translation import ugettext_lazy as _
 
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -14,6 +15,7 @@ from universities.factories import UniversityFactory
 
 
 @skipUnlessLms
+@override_settings(COURSE_SIGNALS_DISABLED=False)
 class FeedTest(ModuleStoreTestCase, RSSDeclarationMixin):
     def setUp(self):
         super(FeedTest, self).setUp()

--- a/courses/signals.py
+++ b/courses/signals.py
@@ -5,6 +5,10 @@ from xmodule.modulestore.django import SignalHandler
 
 @receiver(SignalHandler.course_published, dispatch_uid='fun.courses.signals.update_courses')
 def update_course_meta_data_on_studio_publish(sender, course_key, **kwargs):
+    from django.conf import settings
+    if getattr(settings, "COURSE_SIGNALS_DISABLED", False):
+        return 'FUN courses meta data update has been skipped.'
+
     from .tasks import update_courses_meta_data
     # course_key is a CourseKey object and course_id its sting representation
     update_courses_meta_data.delay(course_id=unicode(course_key))

--- a/fun/envs/cms/test.py
+++ b/fun/envs/cms/test.py
@@ -24,6 +24,10 @@ STATICFILES_STORAGE = 'pipeline.storage.NonPackagingPipelineStorage'
 PIPELINE_ENABLED = False
 
 CACHES.update(test.caches)
+
 ################ Disable Django debug toolbar
 INSTALLED_APPS = tuple([app for app in INSTALLED_APPS if app not in DEBUG_TOOLBAR_INSTALLED_APPS])
 MIDDLEWARE_CLASSES = tuple([m for m in MIDDLEWARE_CLASSES if m not in DEBUG_TOOLBAR_MIDDLEWARE_CLASSES])
+
+# Disable costly calls to publish signals
+COURSE_SIGNALS_DISABLED = True

--- a/fun/envs/lms/test.py
+++ b/fun/envs/lms/test.py
@@ -60,8 +60,12 @@ STATICFILES_STORAGE = 'pipeline.storage.NonPackagingPipelineStorage'
 PIPELINE_ENABLED = False
 
 CACHES.update(test.caches)
+
 ################ Disable Django debug toolbar
 INSTALLED_APPS = tuple([app for app in INSTALLED_APPS if app not in DEBUG_TOOLBAR_INSTALLED_APPS])
 MIDDLEWARE_CLASSES = tuple([m for m in MIDDLEWARE_CLASSES if m not in DEBUG_TOOLBAR_MIDDLEWARE_CLASSES])
 
 FEATURES['USE_MICROSITES'] = False
+
+# Disable costly calls to publish signals
+COURSE_SIGNALS_DISABLED = True


### PR DESCRIPTION
With the course signals that run the update_courses and update_index
scripts, the tests require 2x more time to proceed, and a running
elastic search instance as well. Here we disable the course signals in
test mode.

This closes issue #2552.