### PR TITLE
Fix "all" button padding in course search

### DIFF
--- a/funsite/static/funsite/css/fun.css
+++ b/funsite/static/funsite/css/fun.css
@@ -273,7 +273,7 @@ h3.big-title {
 }
 
 .btn.btn-padded {
-    padding: 12px;
+    padding: 12px 2px 12px 2px;
 }
 .btn.btn-spaced {
     margin-top: 40px;


### PR DESCRIPTION
Left-right padding was too important for the "+ Voir les 55
établissements" button in the course search page. We fix this by keeping
the top/bottom padding but reduce the left-right padding.

This closes issue #2584.