### PR TITLE
Faster backoffice course list

### DIFF
--- a/backoffice/tests/test.py
+++ b/backoffice/tests/test.py
@@ -18,7 +18,7 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from courseware.tests.factories import StaffFactory, InstructorFactory
 from student.models import UserProfile
 
-from backoffice import views
+from backoffice import views_courses
 from fun.tests.utils import skipUnlessLms
 from universities.factories import UniversityFactory
 from courses.models import Course
@@ -115,14 +115,14 @@ class TestDeleteCourse(BaseCourseDetail):
         self.assertEqual(1, Course.objects.filter(key=self.course.id.to_deprecated_string()).count())
 
     def test_delete_course(self):
-        views.logger.warning = mock.Mock()
+        views_courses.logger.warning = mock.Mock()
         data = {'action': 'delete-course'}
         response = self.client.post(self.url, data, follow=True)
         self.assertEqual(None, modulestore().get_course(self.course.id))
         self.assertEqual(0, Course.objects.filter(key=self.course.id.to_deprecated_string()).count())
         self.assertIn(_(u"Course <strong>%s</strong> has been deleted.") % self.course.id,
                       response.content.decode('utf-8'))
-        self.assertEqual(1, views.logger.warning.call_count)
+        self.assertEqual(1, views_courses.logger.warning.call_count)
 
     def test_no_university(self):
         """In a course is not bound to an university, a alert should be shown."""

--- a/backoffice/tests/test.py
+++ b/backoffice/tests/test.py
@@ -71,13 +71,6 @@ class TestAuthentication(BaseBackoffice):
         response = self.client.get(self.list_url)
         self.assertEqual(302, response.status_code)
 
-    def test_users_belonging_to_group_should_login_and_see_no_published_course(self):
-        self.login_with_backoffice_group()
-        response = self.client.get(self.list_url)
-        self.assertEqual(200, response.status_code)
-        # user is not staff so he cannot see any published course
-        self.assertEqual(0, len(response.context['course_infos']))
-
     def test_staff_users_see_all_courses(self):
         self.user.groups.add(self.backoffice_group)
         self.user.is_staff = True

--- a/backoffice/urls.py
+++ b/backoffice/urls.py
@@ -3,11 +3,16 @@
 from django.conf import settings
 from django.conf.urls import include, url, patterns
 
-urlpatterns = patterns('backoffice.views',
+
+urlpatterns = patterns('backoffice.views_courses',
     url(r'^$', 'courses_list', name='courses-list'),
     url(r'^course/{}?$'.format(settings.COURSE_KEY_PATTERN),
             'course_detail', name='course-detail'),
+    url(r'^wiki/{}/(?P<action>[^/]+)?$'.format(settings.COURSE_KEY_PATTERN),
+            'wiki', name='course-wiki'),
+)
 
+urlpatterns += patterns('backoffice.views',
     url(r'^users/$', 'user_list', name='user-list'),
     url(r'^user/(?P<username>[^/]+)/$', 'user_detail', name='user-detail'),
 
@@ -23,6 +28,4 @@ urlpatterns = patterns('backoffice.views',
         r'^course/certificate/{}/'.format(settings.COURSE_KEY_PATTERN),
         include('backoffice.certificate_manager.urls')
     ),
-    url(r'^wiki/{}/(?P<action>[^/]+)?$'.format(settings.COURSE_KEY_PATTERN),
-            'wiki', name='course-wiki'),
 )

--- a/backoffice/views.py
+++ b/backoffice/views.py
@@ -1,225 +1,37 @@
 # -*- coding: utf-8 -*-
 
-import csv
-from collections import namedtuple, defaultdict
-import datetime
+from collections import defaultdict
 import logging
-import re
 
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.db.models import Q
-from django.http import HttpResponse, Http404
-from django.core.urlresolvers import reverse
-from django.db.models import Count
+from django.http import Http404
 from django.shortcuts import render, redirect, get_object_or_404
 from django.utils import timezone
-from django.utils.translation import ugettext, ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 
 from pure_pagination import Paginator, PageNotAnInteger
 
 from bulk_email.models import Optout
 from certificates.models import GeneratedCertificate
-from courseware.courses import course_image_url, get_courses, get_cms_course_link
 from edxmako.shortcuts import render_to_string
 from microsite_configuration import microsite
-from opaque_keys.edx.keys import CourseKey
 from student.models import CourseEnrollment, CourseAccessRole, UserStanding, UserProfile, Registration
 
 from xmodule_django.models import CourseKeyField
-from xmodule.modulestore.django import modulestore
 
-from courses.models import Course, CourseUniversityRelation
-from courses.utils import get_about_section
 from newsfeed.models import Article
-from fun.utils import funwiki as wiki_utils
-from universities.models import University
 
 from .forms import SearchUserForm, UserForm, UserProfileForm, ArticleForm
 from .utils import get_course, group_required, get_course_key
 
-ABOUT_SECTION_FIELDS = ['effort', 'video']
 
 logger = logging.getLogger(__name__)
 
-FunCourse = namedtuple('FunCourse', [
-    'course',
-    'fun',
-    'course_image_url',
-    'students_count',
-    'title',
-    'university',
-    'url',
-    'studio_url'
-] + ABOUT_SECTION_FIELDS)
-
 LIMIT_BY_PAGE = 100
 
-
-def get_about_sections(course_descriptor):
-    about_sections = {
-        field: get_about_section(course_descriptor, field) or ''
-        for field in ABOUT_SECTION_FIELDS
-    }
-    about_sections['effort'] = about_sections['effort'].replace('\n', '')  # clean the many CRs
-    if about_sections['video']:
-        try:  # edX stores the Youtube iframe HTML code, let's extract the Dailymotion Cloud ID
-            about_sections['video'] = re.findall(r'www.youtube.com/embed/(?P<hash>[\w]+)\?', about_sections['video'])[0]
-        except IndexError:
-            pass
-    return about_sections
-
-def get_course_info(course_descriptor, course, students_count):
-    """Returns an object containing original edX course and some complementary properties."""
-    about_sections = get_about_sections(course_descriptor)
-    course_info = FunCourse(
-        course=course_descriptor,
-        fun=course,
-        course_image_url=course_image_url(course_descriptor),
-        students_count=students_count,
-        title=course_descriptor.display_name_with_default,
-        university=course_descriptor.display_org_with_default,
-        url='https://%s%s' % (settings.LMS_BASE,
-                reverse('about_course', args=[course_descriptor.id.to_deprecated_string()])),
-        studio_url=get_cms_course_link(course_descriptor),
-        **about_sections
-    )
-    return course_info
-
-def get_course_enrollment_counts(course_descriptors_ids):
-    queryset = (
-        CourseEnrollment.objects
-        .filter(course_id__in=course_descriptors_ids)
-        .values('course_id')
-        .annotate(total=Count('course_id'))
-     )
-    return {
-        result['course_id']: result['total'] for result in queryset
-    }
-
-def get_course_infos(course_descriptors):
-    course_descriptor_ids = [course_descriptor.id for course_descriptor in course_descriptors]
-    courses = Course.objects.filter(key__in=course_descriptor_ids)
-    course_enrollment_counts = get_course_enrollment_counts(course_descriptor_ids)
-    course_dict = {course.key: course for course in courses}
-    return [
-        get_course_info(
-            course_descriptor,
-            course_dict.get(course_descriptor.id.to_deprecated_string()),
-            course_enrollment_counts.get(course_descriptor.id.to_deprecated_string(), 0)
-        )
-        for course_descriptor in course_descriptors
-    ]
-
-def get_complete_course_info(course_descriptor):
-    return get_course_infos([course_descriptor])[0]
-
-def get_filtered_course_infos(request):
-    course_infos = get_course_infos(get_courses(request.user))
-    pattern = request.GET.get('search')
-
-    if pattern:
-        course_infos = [course for course in course_infos
-                if pattern in course.title
-                or pattern in course.course.id.to_deprecated_string()]
-
-    return course_infos, pattern
-
-def format_datetime(dt):
-    FORMAT = '%Y-%m-%d %H:%M'
-    return dt.strftime(FORMAT) if dt else ''
-
-
-@group_required('fun_backoffice')
-def courses_list(request):
-    course_infos, pattern = get_filtered_course_infos(request)
-
-    if request.method == 'POST':
-        # export as CSV
-        filename = 'export-cours-%s.csv' % datetime.datetime.now().strftime('%Y-%m-%d')
-        response = HttpResponse(content_type='text/csv')
-        response['Content-Disposition'] = 'attachment; filename=%s' % filename
-        writer = csv.writer(response)
-        csv_header = [ugettext(u"Title"), ugettext(u"University"), ugettext(u"Organisation code"),
-                ugettext(u"Course"), ugettext(u"Run"), ugettext(u"Start date"), ugettext(u"End date"),
-                ugettext(u"Enrollment start"), ugettext(u"Enrollment end"), ugettext(u"Students count"),
-                ugettext(u"Effort"), ugettext(u"Image"), ugettext(u"Video"), ugettext(u"Url")]
-        writer.writerow([field.encode('utf-8') for field in csv_header])
-
-        for course_info in course_infos:
-            row = [
-                course_info.title.encode('utf-8'),
-                course_info.university.encode('utf-8'),
-                course_info.course.id.org.encode('utf-8'),
-                course_info.course.id.course.encode('utf-8'),
-                course_info.course.id.run.encode('utf-8'),
-                format_datetime(course_info.course.start),
-                format_datetime(course_info.course.end),
-                format_datetime(course_info.course.enrollment_start),
-                format_datetime(course_info.course.enrollment_end),
-                course_info.students_count,
-                course_info.effort.encode('utf-8'),
-                'https://%s%s' % (
-                    settings.LMS_BASE,
-                    course_info.course_image_url.encode("utf-8")
-                ),
-                course_info.video,
-                course_info.url
-            ]
-            writer.writerow(row)
-        return response
-
-    return render(request, 'backoffice/courses.html', {
-        'course_infos': course_infos,
-        'pattern': pattern,
-        'tab': 'courses',
-    })
-
-
-@group_required('fun_backoffice')
-def course_detail(request, course_key_string):
-    """Course is deleted from Mongo and staff and students enrollments from mySQL.
-    States and responses from students are not yet deleted from mySQL
-    (StudentModule, StudentModuleHistory are very big tables)."""
-
-    course_info = get_complete_course_info(get_course(course_key_string))
-    ck = CourseKey.from_string(course_key_string)
-    funcourse, _created = Course.objects.get_or_create(key=ck)
-    try:
-        university = University.objects.get(code=ck.org)
-    except University.DoesNotExist:
-        messages.warning(request, _(u"University with code <strong>%s</strong> does not exist.") % ck.org)
-        university = None
-    if university and university not in funcourse.universities.all():
-        CourseUniversityRelation.objects.create(course=funcourse, university=university)
-
-    if request.method == 'POST':
-        if request.POST['action'] == 'delete-course':
-            # from xmodule.contentstore.utils.delete_course_and_groups function
-            module_store = modulestore()
-            with module_store.bulk_operations(ck):
-                module_store.delete_course(ck, request.user.id)
-
-            CourseAccessRole.objects.filter(course_id=ck).delete()  # shall we also delete student's enrollments ?
-            funcourse.delete()
-            messages.warning(request, _(u"Course <strong>%s</strong> has been deleted.") % course_info.course.id)
-            logger.warning('Course %s deleted by user %s', course_info.course.id, request.user.username)
-            return redirect('backoffice:courses-list')
-
-    try:
-        university = University.objects.get(code=course_info.course.org)
-    except University.DoesNotExist:
-        university = None
-
-    roles = CourseAccessRole.objects.filter(course_id=ck)
-
-    return render(request, 'backoffice/course.html', {
-            'course_info': course_info,
-            'university': university,
-            'roles': roles,
-            'tab': 'courses',
-        })
 
 
 def order_and_paginate_queryset(request, queryset, default_order):
@@ -429,37 +241,3 @@ def news_detail(request, news_id=None):
         'form': form,
         'tab': 'news',
     })
-
-
-@group_required('fun_backoffice')
-def wiki(request, course_key_string, action=None):
-    course_info = get_complete_course_info(get_course(course_key_string))
-
-    ck = CourseKey.from_string(course_key_string)
-    course = modulestore().get_course(ck)
-
-    base_page = wiki_utils.get_base_page(course)
-
-    if request.method == 'POST':
-        value, word = {'open': (True, _(u"opened")), 'close': (False, _(u"closed"))}[request.POST['action']]
-        result = wiki_utils.set_permissions(course, value)
-        if result:
-            messages.success(request, _(u"Wiki was successfully ") + unicode(word))
-        else:
-            messages.error(request, _(u"Wiki could not be ") + unicode(word))
-
-        return redirect(reverse('backoffice:course-wiki', args=[course_key_string]))
-
-    pages = wiki_utils.get_page_tree([base_page])
-    html = _(u"This course has no wiki")
-    if any(pages):
-        pages, html = wiki_utils.render_html_tree(pages, '')
-
-    return render(request, 'backoffice/wiki.html', {
-            'course_key_string': course_key_string,
-            'course_info': course_info,
-            'pages': pages,
-            'html': html,
-            'tab': 'courses',
-        })
-

--- a/backoffice/views_courses.py
+++ b/backoffice/views_courses.py
@@ -1,0 +1,249 @@
+# -*- coding: utf-8 -*-
+import csv
+from collections import namedtuple
+import datetime
+import logging
+import re
+
+from django.conf import settings
+from django.contrib import messages
+from django.core.urlresolvers import reverse
+from django.db.models import Count
+from django.http import HttpResponse
+from django.shortcuts import render, redirect
+from django.utils.translation import ugettext, ugettext_lazy as _
+
+from courses.models import Course, CourseUniversityRelation
+from courses.utils import get_about_section
+from courseware.courses import get_courses, course_image_url, get_cms_course_link
+from opaque_keys.edx.keys import CourseKey
+from student.models import CourseEnrollment, CourseAccessRole
+from universities.models import University
+from xmodule.modulestore.django import modulestore
+
+from fun.utils import funwiki as wiki_utils
+from .utils import get_course, group_required
+
+
+logger = logging.getLogger(__name__)
+
+COURSE_FIELDS = [
+    'course',
+    'fun',
+    'course_image_url',
+    'students_count',
+    'title',
+    'university',
+    'url',
+    'studio_url'
+]
+ABOUT_SECTION_FIELDS = ['effort', 'video']
+FunCourse = namedtuple('FunCourse', COURSE_FIELDS + ABOUT_SECTION_FIELDS)
+CompleteFunCourse = namedtuple('CompleteFunCourse', COURSE_FIELDS + ABOUT_SECTION_FIELDS)
+
+
+@group_required('fun_backoffice')
+def courses_list(request):
+    search_pattern = request.GET.get('search')
+    courses = get_courses(request.user)
+    course_infos = get_filtered_course_infos(courses, search_pattern=search_pattern)
+
+    if request.method == 'POST':
+        # export as CSV
+        filename = 'export-cours-%s.csv' % datetime.datetime.now().strftime('%Y-%m-%d')
+        response = HttpResponse(content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename=%s' % filename
+        writer = csv.writer(response)
+        csv_header = [ugettext(u"Title"), ugettext(u"University"), ugettext(u"Organisation code"),
+                ugettext(u"Course"), ugettext(u"Run"), ugettext(u"Start date"), ugettext(u"End date"),
+                ugettext(u"Enrollment start"), ugettext(u"Enrollment end"), ugettext(u"Students count"),
+                ugettext(u"Effort"), ugettext(u"Image"), ugettext(u"Video"), ugettext(u"Url")]
+        writer.writerow([field.encode('utf-8') for field in csv_header])
+
+        for course_info in course_infos:
+            row = [
+                course_info.title.encode('utf-8'),
+                course_info.university.encode('utf-8'),
+                course_info.course.id.org.encode('utf-8'),
+                course_info.course.id.course.encode('utf-8'),
+                course_info.course.id.run.encode('utf-8'),
+                format_datetime(course_info.course.start),
+                format_datetime(course_info.course.end),
+                format_datetime(course_info.course.enrollment_start),
+                format_datetime(course_info.course.enrollment_end),
+                course_info.students_count,
+                course_info.effort.encode('utf-8'),
+                'https://%s%s' % (
+                    settings.LMS_BASE,
+                    course_info.course_image_url.encode("utf-8")
+                ),
+                course_info.video,
+                course_info.url
+            ]
+            writer.writerow(row)
+        return response
+
+    return render(request, 'backoffice/courses.html', {
+        'course_infos': course_infos,
+        'pattern': search_pattern,
+        'tab': 'courses',
+    })
+
+
+@group_required('fun_backoffice')
+def course_detail(request, course_key_string):
+    """Course is deleted from Mongo and staff and students enrollments from mySQL.
+    States and responses from students are not yet deleted from mySQL
+    (StudentModule, StudentModuleHistory are very big tables)."""
+
+    course_info = get_complete_course_info(course_key_string)
+    ck = CourseKey.from_string(course_key_string)
+    funcourse, _created = Course.objects.get_or_create(key=ck)
+    try:
+        university = University.objects.get(code=ck.org)
+    except University.DoesNotExist:
+        messages.warning(request, _(u"University with code <strong>%s</strong> does not exist.") % ck.org)
+        university = None
+    if university and university not in funcourse.universities.all():
+        CourseUniversityRelation.objects.create(course=funcourse, university=university)
+
+    if request.method == 'POST':
+        if request.POST['action'] == 'delete-course':
+            # from xmodule.contentstore.utils.delete_course_and_groups function
+            module_store = modulestore()
+            with module_store.bulk_operations(ck):
+                module_store.delete_course(ck, request.user.id)
+
+            CourseAccessRole.objects.filter(course_id=ck).delete()  # shall we also delete student's enrollments ?
+            funcourse.delete()
+            messages.warning(request, _(u"Course <strong>%s</strong> has been deleted.") % course_info.course.id)
+            logger.warning('Course %s deleted by user %s', course_info.course.id, request.user.username)
+            return redirect('backoffice:courses-list')
+
+    try:
+        university = University.objects.get(code=course_info.course.org)
+    except University.DoesNotExist:
+        university = None
+
+    roles = CourseAccessRole.objects.filter(course_id=ck)
+
+    return render(request, 'backoffice/course.html', {
+            'course_info': course_info,
+            'university': university,
+            'roles': roles,
+            'tab': 'courses',
+        })
+
+
+@group_required('fun_backoffice')
+def wiki(request, course_key_string, action=None):
+    course_info = get_complete_course_info(course_key_string)
+
+    ck = CourseKey.from_string(course_key_string)
+    course = modulestore().get_course(ck)
+
+    base_page = wiki_utils.get_base_page(course)
+
+    if request.method == 'POST':
+        value, word = {'open': (True, _(u"opened")), 'close': (False, _(u"closed"))}[request.POST['action']]
+        result = wiki_utils.set_permissions(course, value)
+        if result:
+            messages.success(request, _(u"Wiki was successfully ") + unicode(word))
+        else:
+            messages.error(request, _(u"Wiki could not be ") + unicode(word))
+
+        return redirect(reverse('backoffice:course-wiki', args=[course_key_string]))
+
+    pages = wiki_utils.get_page_tree([base_page])
+    html = _(u"This course has no wiki")
+    if any(pages):
+        pages, html = wiki_utils.render_html_tree(pages, '')
+
+    return render(request, 'backoffice/wiki.html', {
+            'course_key_string': course_key_string,
+            'course_info': course_info,
+            'pages': pages,
+            'html': html,
+            'tab': 'courses',
+        })
+
+def get_filtered_course_infos(courses, search_pattern=None):
+    course_infos = [FunCourse(**infos) for infos in get_course_infos(courses)]
+
+    if search_pattern:
+        course_infos = [course for course in course_infos
+                if search_pattern in course.title
+                or search_pattern in course.course.id.to_deprecated_string()]
+
+    return course_infos
+
+def get_complete_course_info(course_key_string):
+    """Complete course info for displaying the details of a course.
+
+    Returns:
+        CompleteFunCourse
+    """
+    course = get_course(course_key_string)
+    course_infos = get_course_infos([course])[0]
+    return CompleteFunCourse(**course_infos)
+
+def get_course_infos(course_descriptors):
+    course_descriptor_ids = [course_descriptor.id for course_descriptor in course_descriptors]
+    courses = Course.objects.filter(key__in=course_descriptor_ids)
+    course_enrollment_counts = get_course_enrollment_counts(course_descriptor_ids)
+    course_dict = {course.key: course for course in courses}
+    return [
+        get_course_info(
+            course_descriptor,
+            course_dict.get(course_descriptor.id.to_deprecated_string()),
+            course_enrollment_counts.get(course_descriptor.id.to_deprecated_string(), 0)
+        )
+        for course_descriptor in course_descriptors
+    ]
+
+def get_course_info(course_descriptor, course, students_count):
+    """Returns a dict containing original edX course and some complementary properties."""
+    course_info = {
+        'course': course_descriptor,
+        'fun': course,
+        'course_image_url': course_image_url(course_descriptor),
+        'students_count': students_count,
+        'title': course_descriptor.display_name_with_default,
+        'university': course_descriptor.display_org_with_default,
+        'url': 'https://%s%s' % (
+            settings.LMS_BASE,
+            reverse('about_course', args=[course_descriptor.id.to_deprecated_string()])
+        ),
+        'studio_url': get_cms_course_link(course_descriptor),
+    }
+    course_info.update(get_about_sections(course_descriptor))
+    return course_info
+
+def get_course_enrollment_counts(course_descriptors_ids):
+    queryset = (
+        CourseEnrollment.objects
+        .filter(course_id__in=course_descriptors_ids)
+        .values('course_id')
+        .annotate(total=Count('course_id'))
+     )
+    return {
+        result['course_id']: result['total'] for result in queryset
+    }
+
+def get_about_sections(course_descriptor):
+    about_sections = {
+        field: get_about_section(course_descriptor, field) or ''
+        for field in ABOUT_SECTION_FIELDS
+    }
+    about_sections['effort'] = about_sections['effort'].replace('\n', '')  # clean the many CRs
+    if about_sections['video']:
+        try:  # edX stores the Youtube iframe HTML code, let's extract the Dailymotion Cloud ID
+            about_sections['video'] = re.findall(r'www.youtube.com/embed/(?P<hash>[\w]+)\?', about_sections['video'])[0]
+        except IndexError:
+            pass
+    return about_sections
+
+def format_datetime(dt):
+    FORMAT = '%Y-%m-%d %H:%M'
+    return dt.strftime(FORMAT) if dt else ''
+

--- a/backoffice/views_courses.py
+++ b/backoffice/views_courses.py
@@ -15,7 +15,7 @@ from django.utils.translation import ugettext, ugettext_lazy as _
 
 from courses.models import Course, CourseUniversityRelation
 from courses.utils import get_about_section
-from courseware.courses import get_courses, course_image_url, get_cms_course_link
+from courseware.courses import course_image_url, get_cms_course_link
 from opaque_keys.edx.keys import CourseKey
 from student.models import CourseEnrollment, CourseAccessRole
 from universities.models import University
@@ -45,8 +45,7 @@ CompleteFunCourse = namedtuple('CompleteFunCourse', COURSE_FIELDS + ABOUT_SECTIO
 @group_required('fun_backoffice')
 def courses_list(request):
     search_pattern = request.GET.get('search')
-    courses = get_courses(request.user)
-    course_infos = get_filtered_course_infos(courses, search_pattern=search_pattern)
+    course_infos = get_filtered_course_infos(search_pattern=search_pattern)
 
     if request.method == 'POST':
         # export as CSV
@@ -167,8 +166,9 @@ def wiki(request, course_key_string, action=None):
             'tab': 'courses',
         })
 
-def get_filtered_course_infos(courses, search_pattern=None):
-    course_infos = [FunCourse(**infos) for infos in get_course_infos(courses)]
+def get_filtered_course_infos(search_pattern=None):
+    courses = modulestore().get_courses()
+    course_infos = get_course_infos(courses)
 
     if search_pattern:
         course_infos = [course for course in course_infos

--- a/backoffice/views_courses.py
+++ b/backoffice/views_courses.py
@@ -242,6 +242,7 @@ def get_course_enrollment_counts(course_descriptors_ids):
         .filter(course_id__in=course_descriptors_ids)
         .values('course_id')
         .annotate(total=Count('course_id'))
+        .order_by()
      )
     return {
         result['course_id']: result['total'] for result in queryset


### PR DESCRIPTION
Here, we use a couple tricks to accelerate the listing of courses from the backoffice. In particular, we get rid of a couple superfluous pieces of information in the course list.

I'm not 100% sure this is going to address the speed issue in production. If not, we will have to profile that code in production.

This closes (hopefully) issue #2548.