### PR TITLE
Avoid tagline caching

### DIFF
--- a/funsite/templates/lms/index.html
+++ b/funsite/templates/lms/index.html
@@ -14,7 +14,6 @@ course_subjects = CourseSubject.objects.random_featured()
 universities = University.objects.featured(18)
 featured_courses = Course.objects.random_featured(10)
 news = top_news(5)
-tagline = _("Higher Education Excellence. Online, Free and Open Courses")
 %>
 
 <%inherit file="funsite/parts/base-fixed-width.html" />
@@ -63,7 +62,7 @@ tagline = _("Higher Education Excellence. Online, Free and Open Courses")
 
 <%block name="content_fullwidth">
     <div class="homepage-header drop-down">
-        <h1>${_("FUN:")} ${tagline}</h1>
+        <h1>${_("FUN:")} ${_("Higher Education Excellence. Online, Free and Open Courses")}</h1>
         <img class="logo-fun" src="${staticfiles_storage.url(settings.FUN_BIG_LOGO_RELATIVE_PATH)}"></img>
     </div>
 </%block>


### PR DESCRIPTION
The tagline was being cached by mako. That resulted in incorrect tagline
languages.

This closes issue #2610.