### PR TITLE
Do not list universities with no associated detailed page

### DIFF
--- a/universities/managers.py
+++ b/universities/managers.py
@@ -23,5 +23,9 @@ class UniversityQuerySet(models.query.QuerySet):
 class UniversityManager(ChainableManager):
     queryset_class = UniversityQuerySet
 
-    def featured(self, limit_to=7):
-        return self.not_obsolete().with_related().by_score()[:limit_to]
+    def featured(self, limit_to=None):
+        """Featured universities have a detail page and are not obsolete"""
+        qs = self.not_obsolete().detail_page_enabled().with_related().by_score()
+        if limit_to is not None:
+            qs = qs[:limit_to]
+        return qs

--- a/universities/tests/test_views.py
+++ b/universities/tests/test_views.py
@@ -16,7 +16,7 @@ class UniversityQuerysetsTests(TestCase):
         listed_universities = list(views.UniversityLandingView().get_queryset())
 
         self.assertTrue(u1 in listed_universities)
-        self.assertTrue(u2 in listed_universities)
+        self.assertFalse(u2 in listed_universities)
         self.assertFalse(u3 in listed_universities)
         self.assertFalse(u4 in listed_universities)
 
@@ -28,8 +28,8 @@ class UniversityQuerysetsTests(TestCase):
 
         featured_universities = list(models.University.objects.featured(4))
 
+        self.assertTrue(u1 in featured_universities)
+        self.assertFalse(u2 in featured_universities)
         self.assertFalse(u3 in featured_universities)
         self.assertFalse(u4 in featured_universities)
-        self.assertEqual(2, len(featured_universities))
-        self.assertEqual(u2, featured_universities[0])
-        self.assertEqual(u1, featured_universities[1])
+        self.assertEqual(1, len(featured_universities))

--- a/universities/views.py
+++ b/universities/views.py
@@ -10,7 +10,7 @@ class UniversityLandingView(mako.MakoTemplateMixin, ListView):
     context_object_name = 'universities'
 
     def get_queryset(self):
-        return University.objects.not_obsolete().by_score()
+        return University.objects.featured()
 
 
 class UniversityDetailView(mako.MakoTemplateMixin, DetailView):


### PR DESCRIPTION
Universities for which is_detail_page_enabled=False should not be
displayed on the front page nor on the universities page. Note that they
do remain in the course search filter list.

This closes issue #2537.