### PR TITLE
Fix fun header in verification pages

### DIFF
--- a/fun/envs/lms/common.py
+++ b/fun/envs/lms/common.py
@@ -217,6 +217,9 @@ JWT_EXPIRATION = 30
 OAUTH_ENFORCE_SECURE = False
 OAUTH_OIDC_ISSUER = "http://localhost:8000/oauth2"
 
+# Append fun header script to verification pages
+PIPELINE_JS['rwd_header']['source_filenames'].append('funsite/js/header.js')
+
 # A user is verified if he has an approved SoftwareSecurePhotoVerification entry
 # this setting will create a dummy SoftwareSecurePhotoVerification for user in paybox success callback view
 # I think it's better to create a dummy one than to remove verifying process in edX

--- a/fun/envs/lms/common.py
+++ b/fun/envs/lms/common.py
@@ -187,8 +187,8 @@ PIPELINE_CSS['style-main']['source_filenames'].append('funsite/css/footer.css')
 PIPELINE_CSS['style-main']['source_filenames'].append('forum_contributors/highlight/css/highlight.css')
 
 # js/lms-application.js
-PIPELINE_JS['application']['source_filenames'].append('fun/js/cookie-banner.js')
 PIPELINE_JS['application']['source_filenames'].append('funsite/js/header.js')
+PIPELINE_JS['application']['source_filenames'].append('fun/js/cookie-banner.js')
 
 FEATURES['ENABLE_DASHBOARD_SEARCH'] = True  # display a search box in student's dashboard to search in courses he is enrolled in.
 FEATURES['ENABLE_COURSE_DISCOVERY'] = False  # display a search box and enable Backbone app on edX's course liste page which we do not use.

--- a/fun/envs/lms/common.py
+++ b/fun/envs/lms/common.py
@@ -188,7 +188,6 @@ PIPELINE_CSS['style-main']['source_filenames'].append('forum_contributors/highli
 
 # js/lms-application.js
 PIPELINE_JS['application']['source_filenames'].append('fun/js/cookie-banner.js')
-PIPELINE_JS['application']['source_filenames'].append('fun/js/search-site.js')
 PIPELINE_JS['application']['source_filenames'].append('funsite/js/header.js')
 
 FEATURES['ENABLE_DASHBOARD_SEARCH'] = True  # display a search box in student's dashboard to search in courses he is enrolled in.

--- a/fun/envs/lms/common.py
+++ b/fun/envs/lms/common.py
@@ -194,10 +194,15 @@ PIPELINE_JS['application']['source_filenames'].append('funsite/js/header.js')
 FEATURES['ENABLE_DASHBOARD_SEARCH'] = True  # display a search box in student's dashboard to search in courses he is enrolled in.
 FEATURES['ENABLE_COURSE_DISCOVERY'] = False  # display a search box and enable Backbone app on edX's course liste page which we do not use.
 
-FEATURES['ENABLE_PAYMENT_FAKE'] = False
+# Payment
+FEATURES["ENABLE_OAUTH2_PROVIDER"] = True
+FEATURES['ENABLE_PAYMENT_FAKE'] = True
+FEATURES["ENABLE_CREDIT_API"] = True
+FEATURES["ENABLE_CREDIT_ELIGIBILITY"] = True
+FEATURES["ENABLE_MOBILE_REST_API"] = True
+FEATURES['ENABLE_COMBINED_LOGIN_REGISTRATION'] = False
 
 PAID_COURSE_REGISTRATION_CURRENCY=["EUR", "€"]
-
 
 EDX_API_KEY = 'test'
 
@@ -217,14 +222,3 @@ OAUTH_OIDC_ISSUER = "http://localhost:8000/oauth2"
 # this setting will create a dummy SoftwareSecurePhotoVerification for user in paybox success callback view
 # I think it's better to create a dummy one than to remove verifying process in edX
 FUN_ECOMMERCE_AUTOMATIC_VERIFICATION = True
-
-
-FEATURES["ENABLE_CREDIT_API"] = True
-FEATURES["ENABLE_CREDIT_ELIGIBILITY"] = True
-FEATURES["ENABLE_MOBILE_REST_API"] = True
-FEATURES["ENABLE_OAUTH2_PROVIDER"] = True
-FEATURES['ENABLE_COMBINED_LOGIN_REGISTRATION'] = True
-FEATURES['AUTOMATIC_AUTH_FOR_TESTING'] = True
-FEATURES['ENABLE_DISCUSSION_SERVICE'] = False
-FEATURES['ENABLE_COURSE_DISCOVERY'] = False
-

--- a/fun/envs/lms/dev.py
+++ b/fun/envs/lms/dev.py
@@ -39,4 +39,5 @@ HAYSTACK_CONNECTIONS = configure_haystack(ELASTIC_SEARCH_CONFIG)
 
 # If your development environment is not exposed to internet and can not receive payment processor notification
 # by settings this to True, the success return page will generate the appropriate POST to ecommerce service
-FUN_ECOMMERCE_DEBUG_NO_NOTIFICATION = True
+FUN_ECOMMERCE_DEBUG_NO_NOTIFICATION = False
+FEATURES['ENABLE_AUTO_AUTH'] = True

--- a/fun/static/fun/js/cookie-banner.js
+++ b/fun/static/fun/js/cookie-banner.js
@@ -1,20 +1,3 @@
-// Note: this function should probably be in a separate script file, as it is
-// used elsewhere.
-function checkCookie(name) {
-    var nameEQ = name + "=";
-    var ca = document.cookie.split(';');
-    for (var i=0;i < ca.length;i++) {
-        var c = ca[i];
-        while (c.charAt(0)==' ') {
-            c = c.substring(1,c.length);
-        }
-        if (c.indexOf(nameEQ) === 0) {
-            return c.substring(nameEQ.length,c.length);
-        }
-    }
-    return null;
-}
-
 (function() {
     var cookieName = 'acceptCookieFun';
     var cookieValue = "on";

--- a/funsite/static/funsite/js/header.js
+++ b/funsite/static/funsite/js/header.js
@@ -1,4 +1,18 @@
 /* This file is included both in funsite and edx-platorm/lms */
+function checkCookie(name) {
+    var nameEQ = name + "=";
+    var ca = document.cookie.split(';');
+    for (var i=0;i < ca.length;i++) {
+        var c = ca[i];
+        while (c.charAt(0)==' ') {
+            c = c.substring(1,c.length);
+        }
+        if (c.indexOf(nameEQ) === 0) {
+            return c.substring(nameEQ.length,c.length);
+        }
+    }
+    return null;
+}
 
 (function() {
     /* select current page menu item */


### PR DESCRIPTION
The header.js script was not loaded in the verification pages. Note that the header.js needed the checkCookie function from the cookie-banner.js script, which we moved.

In this PR, we hit two birds with one stone and fix an issue related to adblocking (issue #2541) and the verification pages (issue #2642).