### PR TITLE
Quickfix for bulk certificate generation

### DIFF
--- a/fun_certificates/management/commands/generate_fun_certificates.py
+++ b/fun_certificates/management/commands/generate_fun_certificates.py
@@ -1,19 +1,14 @@
 # Python modules
-import os
 import datetime
 from pytz import UTC
 from pprint import pprint
 from optparse import make_option
-import random
 
 # Django modules
 from django.core.management.base import BaseCommand, CommandError
-from django.conf import settings
 from django.contrib.auth.models import User
-from django.test.client import RequestFactory
 
 # edX modules
-from courseware import grades
 from certificates.models import (
   certificate_status_for_student,
   CertificateStatuses as status)
@@ -22,13 +17,6 @@ from opaque_keys.edx.keys import CourseKey
 from opaque_keys import InvalidKeyError
 
 from backoffice.certificate_manager.utils import get_certificate_params, generate_fun_certificate
-from fun_certificates.generator import CertificateInfo
-
-
-factory = RequestFactory()
-request = factory.get('/')
-request.session = {}
-
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
Bulk certificate generation is broken because of undefined variables.
This is a quickfix that solves the problem without addressing the core
concerns, i.e:
- Lack of unit tests of the generate_fun_certificates function
- Difficulty of understanding the generate_fun_certificates, which
  requires an awful lot of parameters
- We really should not need a 'request' object in this function.

This closes issue #2691 but leaves #2693 open.