### PR TITLE
Add pagination in the news page #2600

### DIFF
--- a/fun/envs/lms/common.py
+++ b/fun/envs/lms/common.py
@@ -160,10 +160,12 @@ GRADES_DOWNLOAD_ROUTING_KEY = None
 # Our new home page is so shiny and chrome that users must see it more often
 FEATURES['ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER'] = False
 
-# ??
+# used by pure-pagination app, https://github.com/jamespacileo/django-pure-pagination
+# for information about the constants : https://camo.githubusercontent.com/51defa6771f5db2826a1869eca7bed82d9fb3120/687474703a2f2f692e696d6775722e636f6d2f4c437172742e676966
 PAGINATION_SETTINGS = {
-    'PAGE_RANGE_DISPLAYED': 10,
-    'MARGIN_PAGES_DISPLAYED': 10,
+    # same formatting as in github issues, seems to be sane.
+    'PAGE_RANGE_DISPLAYED': 4,
+    'MARGIN_PAGES_DISPLAYED': 2,
 }
 
 NUMBER_DAYS_TOO_LATE = 31

--- a/funsite/tests/test_views.py
+++ b/funsite/tests/test_views.py
@@ -36,7 +36,7 @@ class TestHomepage(TestCase):
     def test_unpublished_news_are_not_displayed(self):
         article = newsfactories.ArticleFactory.create(published=False)
         response = self.get_root_page()
-        self.assertFalse(str(article.title) in response.content)
+        self.assertFalse(unicode(article.title) in response.content.decode("utf8"))
 
     @setMicrositeTestSettings(FAKE_MICROSITE2)
     def test_news_from_different_microsite_are_not_displayed(self):
@@ -45,7 +45,7 @@ class TestHomepage(TestCase):
             published=True
         )
         response = self.get_root_page()
-        self.assertFalse(str(article.title) in response.content)
+        self.assertFalse(unicode(article.title) in response.content.decode("utf8"))
 
 
 class TestLoginPage(ModuleStoreTestCase):

--- a/newsfeed/templates/newsfeed/article/list.html
+++ b/newsfeed/templates/newsfeed/article/list.html
@@ -12,11 +12,17 @@ from staticfiles.storage import staticfiles_storage
 <%block name="title">${pgettext("fun-news", "News")}</%block>
 <%namespace name="breadcrumbs" file="/funsite/parts/breadcrumbs.html"/>
 <%namespace name="newsfeed" file="./block.html"/>
+<%namespace name="pagination" file="./pagination.html"/>
+
 
 <%block name="content">
 <div class="breadcrumbs-wrapper">
     ${breadcrumbs.breadcrumbs(pgettext("fun-news", "News"))}
 </div>
+<%
+articles_list = articles.object_list[:]
+%>
+
 
 <h1 class="big-title text-center">
     ${_(u"All the news")}
@@ -25,42 +31,51 @@ from staticfiles.storage import staticfiles_storage
 <div class="fun-news news-list">
     ## featured news (only one, displayed regarding resolution)
 
+    %if articles.number == 1 :
     <div class="row">
         <div class="col-lg-36 hidden-sm hidden-xs">
-            % if articles:
-            ${newsfeed.news_block(articles[0], 'big')}
+            % if featured_article:
+            ${newsfeed.news_block(featured_article, 'big')}
             % endif
         </div>
     </div>
+    %endif
 
     <div class="row hidden-md hidden-lg">
+        % if featured_article:
         <div class="col-sm-36 text-center">
-            % if articles:
-            ${newsfeed.news_block(articles[0], 'primary')}
-            % endif
+            ${newsfeed.news_block(featured_article, 'primary')}
         </div>
+        % endif
+
         <div class="col-xs-36 hidden-lg hidden-md hidden-sm text-center">
 
-            % for article in articles[1:]:
+            % for article in articles_list:
                 ${newsfeed.news_block(article, 'primary')}
             % endfor
         </div>
     </div>
 
+    <%
+    left_articles = articles_list[0::2]
+    right_articles = articles_list[1::2]
+    %>
+
     ## chronologically displayed news (on 2 columns)
-    <div class="row hidden-xs">
-        <div class="col-sm-36 col-md-18 no-padding">
-            % for article in articles[1:12:2]:
+     <div class="row hidden-xs">
+         <div class="col-sm-36 col-md-18 no-padding">
+            % for article in left_articles:
                 ${newsfeed.news_block(article, 'secondary', 'left')}
             % endfor
         </div>
         <div class="col-sm-36 col-md-18 no-padding">
-            % for article in articles[2:12:2]:
+            % for article in right_articles:
                 ${newsfeed.news_block(article, 'secondary', 'right')}
             % endfor
         </div>
     </div>
 </div>
 
+${pagination.pages_list(articles)}
 
 </%block>

--- a/newsfeed/templates/newsfeed/article/pagination.html
+++ b/newsfeed/templates/newsfeed/article/pagination.html
@@ -1,0 +1,44 @@
+## mako
+<%!
+from django.utils.translation import ugettext as _
+%>
+
+<%def name="pages_list(article)">
+
+<div class="text-center">
+  <nav>
+    <ul class="pagination">
+      % if articles.has_previous():
+        <li class="page-item">
+          <a class="page-link" href="?p=${articles.previous_page_number()}" aria-label="Previous">
+            <span aria-hidden="true">&laquo;</span>
+            <span class="sr-only">Previous</span>
+          </a>
+        </li>
+      %endif
+
+      %for page in articles.pages():
+        %if page is not None:
+          % if page == articles.number:
+           <li class="active"><a href="?p=${page}">${page}</a></li>
+          %else:
+          <li><a href="?p=${page}">${page}</a></li>
+          %endif
+        %else:
+          <li><span>...</span></li>
+        %endif
+      %endfor
+
+      % if articles.has_next():
+        <li class="page-item">
+          <a class="page-link" href="?p=${articles.next_page_number()}" aria-label="Next">
+            <span aria-hidden="true">&raquo;</span>
+            <span class="sr-only">Next</span>
+          </a>
+        </li>
+      % endif
+    </ul>
+  </nav>
+</div>
+
+</%def>

--- a/newsfeed/tests/factories.py
+++ b/newsfeed/tests/factories.py
@@ -14,7 +14,8 @@ class ArticleCategoryFactory(factory.DjangoModelFactory):
 class ArticleFactory(factory.DjangoModelFactory):
     FACTORY_FOR = models.Article
 
-    title = u"An awesome piece of news"
+    # the number can't be at the end, otherwise, "news1" is in "news10"
+    title = factory.Sequence(lambda n: u"-- An awesome piece of news n° {} --".format(n))
     slug = factory.Sequence(lambda n: 'a-great-slug-{0}'.format(n))
     text = u"J'étais un texte accentué !"
     created_at = factory.lazy_attribute(lambda x: datetime.datetime.now())

--- a/newsfeed/views.py
+++ b/newsfeed/views.py
@@ -9,12 +9,16 @@ from django.utils.translation import ugettext_lazy as _
 
 from edxmako.shortcuts import render_to_response
 
+from pure_pagination import Paginator, EmptyPage
 from microsite_configuration import microsite
 
 from fun.utils.views import staff_required
 
 from . import models
 
+
+
+ARTICLES_PER_PAGE = 10
 
 def get_articles():
     """
@@ -28,6 +32,32 @@ def get_articles():
     """
     return filter_queryset_for_site(models.Article.objects.viewable())
 
+def paginate(queryset, page_nb, article_per_page):
+    """
+    Returns :
+     * a page (a slice of the queryset), with the asked number of articles, at the right offset.
+     * the featured article if the first page is asked or None otherwise
+
+    Note: we use pure_pagination to handle all the complex stuff
+    """
+
+    featured = None
+    if page_nb == 1:
+        featured = queryset[:1]
+        featured = featured[0] if len(featured) > 0 else None
+
+    queryset = queryset[1:]
+    paginator = Paginator(queryset, article_per_page)
+
+    try:
+        paginated = paginator.page(page_nb)
+    except EmptyPage:
+        # If page is out of range (e.g. 9999), deliver last page of results.
+        paginated = paginator.page(paginator.num_pages)
+
+    return paginated, featured
+
+
 def top_news(count=5):
     """Return Top count news if available or fill result list with None for further boolean evaluation."""
     articles = get_articles()[:count]
@@ -35,15 +65,28 @@ def top_news(count=5):
 
 def article_list(request):
     # We exclude the article that's selected in the featured section.
-    return render_articles(get_articles())
+    return render_articles(get_articles(), request.GET)
 
 @staff_required
 def article_list_preview(request, slug):
-    return render_articles(filter_queryset_for_site(models.Article.objects.published_or(slug=slug)))
+    qs = filter_queryset_for_site(models.Article.objects.published_or(slug=slug))
+    return render_articles(qs, request.GET)
 
-def render_articles(articles_queryset):
+def parse_request(get_dict):
+    page = get_dict.get("p", "")
+    page = int(page) if page.isdigit() else 1
+    nb_items = get_dict.get("n", "")
+    nb_items = int(nb_items) if nb_items.isdigit() else ARTICLES_PER_PAGE
+    return page, nb_items
+
+def render_articles(articles_queryset, get_dict):
+    page, nb_items = parse_request(get_dict)
+    articles, featured = paginate(articles_queryset, page, nb_items)
+    # import ipdb; ipdb.set_trace();
+
     return render_to_response('newsfeed/article/list.html', {
-        'articles': list(articles_queryset)
+        'articles': articles,
+        "featured_article": featured,
     })
 
 def filter_queryset_for_site(queryset):


### PR DESCRIPTION
With the growing number of news, we couldn't see all of them in the
/news page.
Hopefully this solves another bug, the complete list of news was
previouly sent in the page, but only visible for small screens.

This closes issue #2600