### PR TITLE
Fix course search sort for courses with no end date

### DIFF
--- a/courses/tests/test_models.py
+++ b/courses/tests/test_models.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from django.test import TestCase
+from django.utils.timezone import now, timedelta
 
 from courses import managers
 from courses import models
@@ -78,3 +79,18 @@ class TestCourseSubject(TestCase):
             for course in models.Course.objects.with_related():
                 _first_university = course.get_first_university()
                 _university_name = course.university_name
+
+    def test_annotate_with_is_enrollment_over(self):
+        yesterday = now() - timedelta(days=1)
+        tomorrow = now() + timedelta(days=1)
+        course_enrollment_ended = factories.CourseFactory.create(enrollment_end_date=yesterday)
+        course_enrollment_not_ended = factories.CourseFactory.create(enrollment_end_date=tomorrow)
+        course_open = factories.CourseFactory.create(enrollment_end_date=None)
+        queryset = models.Course.objects.annotate_with_is_enrollment_over()
+
+        # Note: we do not use assertTrue and assertFalse here because we want
+        # to make sure is_enrollment_over is not None
+        self.assertEqual(True, queryset.get(id=course_enrollment_ended.id).is_enrollment_over)
+        self.assertEqual(False, queryset.get(id=course_enrollment_not_ended.id).is_enrollment_over)
+        self.assertEqual(False, queryset.get(id=course_open.id).is_enrollment_over)
+

--- a/courses_api/filters.py
+++ b/courses_api/filters.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from django.db import connection
-from django.utils.timezone import now
-
 from rest_framework import filters
 
 from haystack.query import SearchQuerySet
@@ -51,14 +48,8 @@ class CourseFilter(filters.BaseFilterBackend):
             results = SearchQuerySet().filter(content=full_text_query)
             queryset = queryset.filter(pk__in=[item.pk for item in results.filter(django_ct='courses.course')])
 
-        # Put archived courses at the end
-        # Note: we are putting raw sql in the extra(...) statement. To do that,
-        # we need the proper datetime formatting, which varies for every db.
-        formatted_now = connection.ops.value_to_db_datetime(now())
-        queryset = queryset.extra(select={
-            'is_archived': 'end_date < "{now}" OR enrollment_end_date < "{now}"'.format(now=formatted_now)
-        })
-
-        queryset = queryset.order_by('is_archived', self.order_by_param(request))
+        # Put courses for which enrollment is over at the end
+        queryset = queryset.annotate_with_is_enrollment_over()
+        queryset = queryset.order_by('is_enrollment_over', self.order_by_param(request))
 
         return queryset

--- a/courses_api/tests/test_api.py
+++ b/courses_api/tests/test_api.py
@@ -118,8 +118,9 @@ class CourseAPITest(TestCase):
     def test_courses_are_sorted_by_enrollment_date(self):
         self.active_1.score = 0
         self.active_2.score = 1
-        self.active_1.enrollment_start_date = now() + timedelta(days=1)
-        self.active_2.enrollment_start_date = now()
+        yesterday = now() - timedelta(days=1)
+        self.active_1.enrollment_start_date = yesterday + timedelta(hours=1)
+        self.active_2.enrollment_start_date = yesterday
         self.active_1.save()
         self.active_2.save()
 
@@ -140,8 +141,9 @@ class CourseAPITest(TestCase):
     def test_courses_are_sorted_by_start_date(self):
         self.active_1.score = 0
         self.active_2.score = 1
-        self.active_1.start_date = now() + timedelta(days=1)
-        self.active_2.start_date = now()
+        yesterday = now() - timedelta(days=1)
+        self.active_1.start_date = yesterday + timedelta(hours=1)
+        self.active_2.start_date = yesterday
         self.active_1.save()
         self.active_2.save()
 
@@ -340,27 +342,9 @@ class CourseAPITest(TestCase):
         self.assertEqual(1, len(data['results']))
         self.assertEqual(self.active_1.title, data['results'][0]['title'])
 
-    def test_ended_courses_are_listed_at_the_end(self):
-        yesterday = now() - timedelta(days=1)
-        tomorrow = now() + timedelta(days=1)
-        self.active_1.end_date = yesterday
-        self.active_2.end_date = tomorrow
-        self.active_1.score = self.active_2.score + 1
-        self.active_1.save()
-        self.active_2.save()
-
-        response = self.client.get(self.api_url, {})
-        data = json.loads(response.content)
-
-        self.assertEqual(2, data["count"])
-        self.assertEqual(self.active_2.id, data["results"][0]["id"])
-        self.assertEqual(self.active_1.id, data["results"][1]["id"])
-
     def test_enrollment_ended_courses_are_listed_at_the_end(self):
         yesterday = now() - timedelta(days=1)
         tomorrow = now() + timedelta(days=1)
-        self.active_1.end_date = tomorrow
-        self.active_2.end_date = tomorrow
         self.active_1.enrollment_end_date = yesterday
         self.active_2.enrollment_end_date = tomorrow
         self.active_1.score = self.active_2.score + 1


### PR DESCRIPTION
Courses with NULL end_date or enrollment_end_date had a is_archived
attribute equal to None, which put them before other courses which had
is_archived = 0 or 1. To solve this issue, we improve the SQL query that
separates courses by accessibility.