### PR TITLE
requirements : add xblock to insert iframe with anonymous id

### DIFF
--- a/requirements/ipython-xblock.txt
+++ b/requirements/ipython-xblock.txt
@@ -1,1 +1,2 @@
 -e git+https://github.com/neurolit/xblock-ipython.git@920082ac5015d2c72899b77959e793c1c7ab2d54#egg=ipython-xblock
+-e git+https://github.com/jgrynber/iframe-id-xblock.git@6cbf37bcdb777c66e13d7198f24e0daeb0bf9221#egg=iframe-id-xblock


### PR DESCRIPTION
Add a repo in requirements/ipython-xblock. 
Xblock lets author/staff insert an iframe that will have an anonymous id added in the url. 

It will be necessary for some Inria's mooc. 