### PR TITLE
Change update courses / search index periodic tasks

### DIFF
--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import datetime
-
 from celery import shared_task
 
 from django.core.management import call_command
@@ -10,11 +8,8 @@ from django.core.management import call_command
 @shared_task
 def update_courses_meta_data(*args, **kwargs):
     '''
-    A task that servers as proxy to the management command.
+    A task that serves as proxy to the management command.
     Can be used for instance when a signal is fired to update
     a single course or to run periodic tasks.
     '''
-
-    now = datetime.datetime.now().isoformat()
     call_command('update_courses', *args, **kwargs)
-    call_command('update_index', start_date=now, *args, **kwargs)

--- a/fun/envs/cms/common.py
+++ b/fun/envs/cms/common.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from datetime import timedelta
 
+from celery.schedules import crontab
+
 from cms.envs.aws import *  # pylint: disable=wildcard-import, unused-wildcard-import
 from ..common import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
@@ -81,8 +83,12 @@ SITE_VARIANT = 'cms'
 # Django `manage.py` with: `celery beat -l INFO`.
 # Ex: `fun cms.dev celery beat -l INFO`
 CELERYBEAT_SCHEDULE = {
-    'update-courses-meta-data-every-30-minutes': {
+    'update-courses-meta-data-periodically': {
         'task': 'courses.tasks.update_courses_meta_data',
-        'schedule': timedelta(minutes=30),
+        'schedule': timedelta(hours=3),
+    },
+    'update-search-index-every-day': {
+        'task': 'fun.tasks.update_search_index',
+        'schedule': crontab(hour=2, minute=30, day_of_week='*'),
     },
 }

--- a/fun/tasks.py
+++ b/fun/tasks.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from celery import shared_task
+
+from django.core.management import call_command
+
+
+@shared_task
+def update_search_index(*args, **kwargs):
+    '''
+    A task that serves as proxy to the management command
+    for updating search index.
+    Can be used for instance to run periodic tasks.
+    '''
+    call_command('update_index', *args, **kwargs)


### PR DESCRIPTION
- Search index is now done independently - not attached to course meta
  data update anymore.
- Change frequency for the course update scheduler.