### PR TITLE
Accelerate calls to TermsAndConditions

### DIFF
--- a/payment/migrations/0002_auto__add_index_termsandconditions_name__add_index_termsandconditions_.py
+++ b/payment/migrations/0002_auto__add_index_termsandconditions_name__add_index_termsandconditions_.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding index on 'TermsAndConditions', fields ['name']
+        db.create_index('payment_termsandconditions', ['name'])
+
+        # Adding index on 'TermsAndConditions', fields ['datetime']
+        db.create_index('payment_termsandconditions', ['datetime'])
+
+
+    def backwards(self, orm):
+        # Removing index on 'TermsAndConditions', fields ['datetime']
+        db.delete_index('payment_termsandconditions', ['datetime'])
+
+        # Removing index on 'TermsAndConditions', fields ['name']
+        db.delete_index('payment_termsandconditions', ['name'])
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'payment.termsandconditions': {
+            'Meta': {'ordering': "['name', '-datetime']", 'object_name': 'TermsAndConditions'},
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '12'})
+        },
+        'payment.useracceptance': {
+            'Meta': {'unique_together': "(['user', 'terms'],)", 'object_name': 'UserAcceptance'},
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'terms': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'accepted'", 'to': "orm['payment.TermsAndConditions']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'terms_accepted'", 'to': "orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['payment']

--- a/payment/migrations/0003_auto__add_index_useracceptance_datetime.py
+++ b/payment/migrations/0003_auto__add_index_useracceptance_datetime.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding index on 'UserAcceptance', fields ['datetime']
+        db.create_index('payment_useracceptance', ['datetime'])
+
+
+    def backwards(self, orm):
+        # Removing index on 'UserAcceptance', fields ['datetime']
+        db.delete_index('payment_useracceptance', ['datetime'])
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'payment.termsandconditions': {
+            'Meta': {'ordering': "['name', '-datetime']", 'object_name': 'TermsAndConditions'},
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '12'})
+        },
+        'payment.useracceptance': {
+            'Meta': {'unique_together': "(['user', 'terms'],)", 'object_name': 'UserAcceptance'},
+            'datetime': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'terms': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'accepted'", 'to': "orm['payment.TermsAndConditions']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'terms_accepted'", 'to': "orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['payment']

--- a/payment/models.py
+++ b/payment/models.py
@@ -8,9 +8,9 @@ PAYMENT_TERMS = 'verified_certificate'
 
 
 class TermsAndConditions(models.Model):
-    name = models.CharField(max_length=100, verbose_name=_(u"Name"))
+    name = models.CharField(max_length=100, verbose_name=_(u"Name"), db_index=True)
     version = models.CharField(max_length=12, verbose_name=_(u"Terms and conditions version (semver)"))
-    datetime = models.DateTimeField(auto_now_add=True, verbose_name=_(u"Acceptance date"))
+    datetime = models.DateTimeField(auto_now_add=True, verbose_name=_(u"Acceptance date"), db_index=True)
     text = models.TextField(verbose_name=_(u"Terms and conditions content (HTML allowed)"))
 
     def __unicode__(self):
@@ -61,7 +61,7 @@ class TermsAndConditions(models.Model):
 class UserAcceptance(models.Model):
     user = models.ForeignKey(User, related_name='terms_accepted')
     terms = models.ForeignKey(TermsAndConditions, related_name='accepted')
-    datetime = models.DateTimeField(auto_now=True, verbose_name=_(u"Acceptance date"))
+    datetime = models.DateTimeField(auto_now=True, verbose_name=_(u"Acceptance date"), db_index=True)
 
     def __unicode__(self):
         return u"%s: %s v%s" % (self.user.username, self.terms.name, self.terms.version)


### PR DESCRIPTION
The TermsAndConditions table did not have indexes for some fields that
were being sorted/filtered upon. This resulted in slower SQL queries.
This is critical, since we make a lot of requests on this table.

This closes issue #2920.