### PR TITLE
Reduces zoom level to print webcerts in one page.

### DIFF
--- a/fun_certificates/templates/certificates/_accomplishment-rendering.html
+++ b/fun_certificates/templates/certificates/_accomplishment-rendering.html
@@ -22,6 +22,24 @@ with django.utils.translation.override('fr'):
     )
 %>
 
+<style>
+    @media print {
+        .accomplishment {
+            zoom: 80%;
+            margin-down: 200px;
+            transform: scale(.8);
+        }
+    }
+</style>
+##
+## <style>
+##     @media print {
+##         .wrapper-accomplishment-rendering {
+##             margin-left: 100px;
+##         }
+##     }
+## </style>
+
 <main class="accomplishment accomplishment-main">
 
     <div class="wrapper-accomplishment-rendering">

--- a/fun_certificates/templates/certificates/_accomplishment-rendering.html
+++ b/fun_certificates/templates/certificates/_accomplishment-rendering.html
@@ -28,6 +28,9 @@ with django.utils.translation.override('fr'):
             zoom: 80%;
             margin-down: 200px;
             transform: scale(.8);
+            page-break-inside: avoid;
+            page-break-after: avoid;
+
         }
     }
 </style>


### PR DESCRIPTION
This only works on chrome, on firefox we need to set the zoom level in print settings...

This closes #2924