### PR TITLE
Fix backoffice infinite redirect

### DIFF
--- a/backoffice/certificate_manager/views.py
+++ b/backoffice/certificate_manager/views.py
@@ -2,7 +2,7 @@
 
 from django.conf import settings
 from django.contrib import messages
-from django.http import HttpResponse
+from django.http import HttpResponse, Http404
 from django.shortcuts import render, redirect
 from django.utils.translation import ugettext_lazy as _
 
@@ -29,6 +29,8 @@ def certificate_dashboard(request, course_key_string):
 
     course_key = get_course_key(course_key_string)
     course = get_course(course_key_string)
+    if course is None:
+        raise Http404
 
     # generate list of pending background tasks and filter the output
     task_types = ['certificate-generation', 'verified-certificate-generation']

--- a/backoffice/utils.py
+++ b/backoffice/utils.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from django.conf import settings
 from django.contrib.auth.decorators import user_passes_test
 from django.db.models import Count
+from django.http import Http404
 
 from pure_pagination import Paginator, PageNotAnInteger
 
@@ -43,7 +44,13 @@ def group_required(*group_names):
                     return UserSignupSource.objects.filter(user=user,
                             site=microsite.get_value('SITE_NAME')).exists()
                 return True
+            else:
+                # 403 errors are not properly handled. As a consequence, we
+                # prefer to display a 404 page.
+                raise Http404()
+        # Redirect to login page
         return False
+
     return user_passes_test(in_groups)
 
 

--- a/backoffice/views/courses_views.py
+++ b/backoffice/views/courses_views.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.db.models import Count
-from django.http import HttpResponse
+from django.http import HttpResponse, Http404
 from django.shortcuts import render, redirect
 from django.utils.translation import ugettext, ugettext_lazy as _
 
@@ -98,10 +98,11 @@ def course_detail(request, course_key_string):
     (StudentModule, StudentModuleHistory are very big tables)."""
 
     ck = CourseKey.from_string(course_key_string)
-
+    course = get_course(course_key_string)
+    if course is None:
+        raise Http404
     mode_count = get_enrollment_mode_count(ck)
-
-    course_info = get_complete_course_info(get_course(course_key_string))
+    course_info = get_complete_course_info(course)
     funcourse, _created = Course.objects.get_or_create(key=ck)
 
     try:


### PR DESCRIPTION
Résout un certain nombre de problème pour accéder dans le backoffice à des objets pour lesquels on ne dispose pas des bonnes permissions ou qui n'existent pas.