### PR TITLE
Deduplicate has_verified_course_mode information from SQL

### DIFF
--- a/courses/admin.py
+++ b/courses/admin.py
@@ -23,7 +23,7 @@ class CourseUniversityRelationInline(admin.TabularInline):
 
 class CourseAdmin(admin.ModelAdmin):
     list_display = ('key', 'title', 'level', 'score', 'session_number',
-        'show_in_catalog', 'is_active', 'prevent_auto_update', 'has_verified_course_mode',
+        'show_in_catalog', 'is_active', 'prevent_auto_update',
         'modification_date', 'certificate_passing_grade')
     list_filter = ('is_active', 'show_in_catalog', 'prevent_auto_update',
         'level', 'subjects', 'universities')
@@ -53,7 +53,6 @@ class CourseAdmin(admin.ModelAdmin):
             'fields': (
                 'key',
                 'show_in_catalog',
-                'has_verified_course_mode',
                 'title',
                 'university_display_name',
                 'image_url',

--- a/courses/management/commands/update_courses.py
+++ b/courses/management/commands/update_courses.py
@@ -162,8 +162,6 @@ class Command(BaseCommand):
         course.enrollment_start_date = mongo_course.enrollment_start
         course.enrollment_end_date = mongo_course.enrollment_end
         course.end_date = mongo_course.end
-        course.has_verified_course_mode = CourseMode.objects.filter(
-                course_id=mongo_course.id, mode_slug='verified').exists()
         course.save()
         self.stdout.write('Updated course {}\n'.format(key))
         return None

--- a/courses/migrations/0038_auto__del_field_course_has_verified_course_mode.py
+++ b/courses/migrations/0038_auto__del_field_course_has_verified_course_mode.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'Course.has_verified_course_mode'
+        db.delete_column('courses_course', 'has_verified_course_mode')
+
+
+    def backwards(self, orm):
+        # Adding field 'Course.has_verified_course_mode'
+        db.add_column('courses_course', 'has_verified_course_mode',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    models = {
+        'courses.course': {
+            'Meta': {'ordering': "('-score',)", 'object_name': 'Course'},
+            'certificate_passing_grade': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'end_date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'enrollment_end_date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'enrollment_start_date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image_url': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            'language': ('django.db.models.fields.CharField', [], {'default': "'fr'", 'max_length': '255', 'db_index': 'True'}),
+            'level': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'modification_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'prevent_auto_update': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'session_number': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'short_description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'show_in_catalog': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'start_date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'subjects': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'courses'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['courses.CourseSubject']"}),
+            'thumbnails_info': ('jsonfield.fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'universities': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'courses'", 'symmetrical': 'False', 'through': "orm['courses.CourseUniversityRelation']", 'to': "orm['universities.University']"}),
+            'university_display_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        'courses.coursesubject': {
+            'Meta': {'ordering': "('-score', 'name', 'id')", 'object_name': 'CourseSubject'},
+            'description': ('ckeditor.fields.RichTextField', [], {'blank': 'True'}),
+            'featured': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'short_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'courses.courseuniversityrelation': {
+            'Meta': {'ordering': "('order', 'id')", 'unique_together': "(('university', 'course'),)", 'object_name': 'CourseUniversityRelation'},
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_universities'", 'to': "orm['courses.Course']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'university': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_courses'", 'to': "orm['universities.University']"})
+        },
+        'universities.university': {
+            'Meta': {'ordering': "('-score', 'id')", 'object_name': 'University'},
+            'banner': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'certificate_logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'description': ('ckeditor.fields.RichTextField', [], {'blank': 'True'}),
+            'detail_page_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_obsolete': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'partnership_level': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'blank': 'True'}),
+            'prevent_auto_update': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'score': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'short_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['courses']

--- a/courses/settings.py
+++ b/courses/settings.py
@@ -13,5 +13,5 @@ FUN_THUMBNAIL_OPTIONS = getattr(settings, 'FUN_THUMBNAIL_OPTIONS', {
 COURSE_ADMIN_READ_ONLY_FIELDS = getattr(settings, 'COURSE_ADMIN_READ_ONLY_FIELDS',
     ('key', 'title', 'image_url', 'university_display_name', 'show_in_catalog',
     'start_date', 'end_date', 'enrollment_start_date', 'enrollment_end_date',
-    'thumbnails_info', 'has_verified_course_mode')
+    'thumbnails_info')
 )

--- a/courses_api/serializers.py
+++ b/courses_api/serializers.py
@@ -36,6 +36,7 @@ class CourseSerializer(serializers.ModelSerializer):
     course_ended = serializers.BooleanField(source='course_ended')
     course_started = serializers.BooleanField(source='course_started')
     university_name = serializers.CharField(source='university_name')
+    has_verified_course_mode = serializers.SerializerMethodField('get_has_verified_course_mode')
 
     class Meta:
         model = Course
@@ -75,6 +76,8 @@ class CourseSerializer(serializers.ModelSerializer):
             return None
         return self.university_serializer_class(instance=main_university).data
 
+    def get_has_verified_course_mode(self, obj):
+        return obj.has_verified_course_mode
 
 class PrivateCourseSerializer(CourseSerializer):
     '''


### PR DESCRIPTION
has_verified_course_mode was being added by the update_courses script
while the information was already present in the CourseMode table. Here,
we deduplicate this information by using a cache that is local to the
fun Course model. This cache is only valid for a couple seconds and
should thus expire after every couple requests.