### PR TITLE
Perform multiple proctorU API queries if the interval is too large

### DIFF
--- a/backoffice/certificate_manager/tasks_verified.py
+++ b/backoffice/certificate_manager/tasks_verified.py
@@ -4,6 +4,7 @@ This file contains backoffice tasks that are designed to perform background oper
 
 import os
 from time import time
+import datetime
 
 from certificates.models import CertificateStatuses
 from instructor_task.tasks_helper import TaskProgress
@@ -73,7 +74,9 @@ def iter_generated_course_verified_certificates(course_id):
     teachers = get_teachers_list_from_course(unicode(course_id))
 
     # Get information from ProctorU
-    proctoru_reports = get_proctorU_students(course_id.course, course_id.run, student_grades=None)
+    today = datetime.datetime.today()
+    begin = today - datetime.timedelta(300)
+    proctoru_reports = get_proctorU_students(course_id.course, course_id.run, begin=begin, student_grades=None)
 
     for student in get_enrolled_verified_students(course_id):
         # Note that if a certificate was generated and proctoru changed its

--- a/backoffice/tests/proctoru_data.json
+++ b/backoffice/tests/proctoru_data.json
@@ -94,7 +94,92 @@
       }
     ]
   },
-
+  "multiple_queries": [
+    {
+      "message": "",
+      "response_code": 1,
+      "data": [
+        {
+          "ProctorNotes": "Reservation created1",
+          "IncidentReport": false,
+          "Authenticated": false,
+          "Test": "Cours Run",
+          "Student": "KVDSQTVG",
+          "CheckID": false,
+          "exam_id": "",
+          "Escalated": false,
+          "SchoolNotes": "Password is - password Exam Notes - Closed Book",
+          "StartDate": "2016-03-25T16:35:00Z",
+          "LoginVerified": false,
+          "EndDate": "2016-03-25T16:50:00Z",
+          "UniqueId": "26",
+          "TestSubmitted": false,
+          "ReservationNo": 2724493,
+          "StudentNotes": null
+        },
+        {
+          "ProctorNotes": "Reservation cancelled1",
+          "IncidentReport": false,
+          "Authenticated": false,
+          "Test": "Cours Run",
+          "Student": "KVDSQTVG",
+          "CheckID": false,
+          "exam_id": "",
+          "Escalated": false,
+          "SchoolNotes": "Password is - password Exam Notes - Closed Book",
+          "StartDate": "2016-03-25T16:35:00Z",
+          "LoginVerified": false,
+          "EndDate": "2016-03-25T16:50:00Z",
+          "UniqueId": "26",
+          "TestSubmitted": false,
+          "ReservationNo": 2724493,
+          "StudentNotes": null
+        }
+      ]
+    },
+    {
+      "message": "",
+      "response_code": 1,
+      "data": [
+        {
+          "ProctorNotes": "Reservation created2",
+          "IncidentReport": false,
+          "Authenticated": false,
+          "Test": "Cours Run",
+          "Student": "KVDSQTVG",
+          "CheckID": false,
+          "exam_id": "",
+          "Escalated": false,
+          "SchoolNotes": "Password is - password Exam Notes - Closed Book",
+          "StartDate": "2016-03-25T16:35:00Z",
+          "LoginVerified": false,
+          "EndDate": "2016-03-25T16:50:00Z",
+          "UniqueId": "26",
+          "TestSubmitted": false,
+          "ReservationNo": 2724493,
+          "StudentNotes": null
+        },
+        {
+          "ProctorNotes": "Reservation cancelled2",
+          "IncidentReport": false,
+          "Authenticated": false,
+          "Test": "Cours Run",
+          "Student": "KVDSQTVG",
+          "CheckID": false,
+          "exam_id": "",
+          "Escalated": false,
+          "SchoolNotes": "Password is - password Exam Notes - Closed Book",
+          "StartDate": "2016-03-25T16:35:00Z",
+          "LoginVerified": false,
+          "EndDate": "2016-03-25T16:50:00Z",
+          "UniqueId": "26",
+          "TestSubmitted": false,
+          "ReservationNo": 2724493,
+          "StudentNotes": null
+        }
+      ]
+    }
+  ],
   "stall":
     {"data": "",
      "message": "stale request",

--- a/backoffice/tests/test_proctoru.py
+++ b/backoffice/tests/test_proctoru.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from collections import namedtuple
+import datetime
 import json
 import os
 
@@ -10,6 +11,7 @@ from student.tests.factories import UserFactory
 
 from .. import utils_proctorU_api
 
+from .test import BaseTestCase
 from .test_course_list import VerifiedCourseList
 
 
@@ -19,6 +21,18 @@ def proctorU_api_result(test_key):
     obj = json.loads(open(json_path).read())
     return obj[test_key]
 
+def simulate_procotru_multiple_resp(first_resps):
+    """
+    Emulate the pagnation in proctoru API. To keep tings simple, we don't react to the date but send the responses
+    written in the json data file then we send empty responses
+    :param first_resps: the first responses to send
+    :yield: the API response
+    """
+    empty = {"message": "", "response_code": 1, "data": []}
+    for resp in first_resps:
+        yield resp
+    while True:
+        yield empty
 
 class TestVerifiedTab(VerifiedCourseList):
 
@@ -27,22 +41,26 @@ class TestVerifiedTab(VerifiedCourseList):
         mock_api.return_value = proctorU_api_result("duplicated")
         UserFactory(last_name="26", username="plop")
 
-        resp = utils_proctorU_api.get_proctorU_students("Cours", "Run", student_grades={})
+        start_date = datetime.datetime(day=01, month=04, year=01)
+        resp = utils_proctorU_api.get_proctorU_students("Cours", "Run", start_date, student_grades={})
         self.assertEqual(1, len(resp["plop"]))
 
     @patch("backoffice.utils_proctorU_api.query_api")
     def test_proctorU_api_parsing_empty_response(self, mock_api):
         mock_api.return_value = proctorU_api_result("empty")
 
-        resp = utils_proctorU_api.get_proctorU_students("Cours", "Run", student_grades={})
+        start_date = datetime.datetime(day=01, month=04, year=01)
+        resp = utils_proctorU_api.get_proctorU_students("Cours", "Run", start_date, student_grades={})
         self.assertEqual("Empty response from the API", resp["error"])
 
     @patch("backoffice.utils_proctorU_api.query_api")
     def test_proctorU_api_user_aggregation(self, mock_api):
-        mock_api.return_value = proctorU_api_result("student-aggregation")
+        mock_api.side_effect = simulate_procotru_multiple_resp([proctorU_api_result("student-aggregation")])
         UserFactory(last_name="26", username="plop")
 
-        resp = utils_proctorU_api.get_proctorU_students("Cours", "Run", student_grades={})
+        today = datetime.datetime.today()
+        begin = today - datetime.timedelta(100)
+        resp = utils_proctorU_api.get_proctorU_students("Cours", "Run", begin, student_grades={})
         self.assertEqual(2, len(resp["plop"]))
         self.assertEqual("Reservation created", resp["plop"][0]["ProctorNotes"])
         self.assertEqual("Reservation cancelled", resp["plop"][1]["ProctorNotes"])
@@ -52,7 +70,8 @@ class TestVerifiedTab(VerifiedCourseList):
         mock_api.return_value = proctorU_api_result("student-aggregation")
         UserFactory(last_name="26")
 
-        resp = utils_proctorU_api.get_proctorU_students("No one", "likes me", student_grades={})
+        start_date = datetime.datetime(day=01, month=04, year=01)
+        resp = utils_proctorU_api.get_proctorU_students("No one", "likes me", start_date, student_grades={})
         self.assertIn("id", resp["warn"])
         self.assertIn("start", resp["warn"])
         self.assertIn("end", resp["warn"])
@@ -66,3 +85,36 @@ class TestVerifiedTab(VerifiedCourseList):
         resp = utils_proctorU_api.query_api(request_mock, "example.com", data)
         self.assertEqual(json.loads(val), resp)
         self.assertIn("time_sent", data)
+
+    @patch("backoffice.utils_proctorU_api.query_api")
+    def test_proctorU_multiple_query_api(self, mock_api):
+        mock_api.side_effect = simulate_procotru_multiple_resp(proctorU_api_result("multiple_queries"))
+        UserFactory(last_name="26", username="plop")
+
+        today = datetime.datetime.today()
+        begin = today - datetime.timedelta(100)
+        resp = utils_proctorU_api.get_proctorU_students("Cours", "Run", begin, student_grades={})
+        self.assertEqual(4, len(resp["plop"]))
+        self.assertEqual("Reservation created1", resp["plop"][0]["ProctorNotes"])
+        self.assertEqual("Reservation cancelled1", resp["plop"][1]["ProctorNotes"])
+        self.assertEqual("Reservation created2", resp["plop"][2]["ProctorNotes"])
+        self.assertEqual("Reservation cancelled2", resp["plop"][3]["ProctorNotes"])
+
+
+class TestProctoruUtils(BaseTestCase):
+    def test_split_date_range(self):
+        start_date = datetime.datetime(day=01, month=04, year=01)
+        end_date = start_date + datetime.timedelta(34)
+
+        dr = list(utils_proctorU_api.split_large_date_range(start_date, end_date, 1))
+        self.assertEqual(34, len(dr))
+        self.assertTrue(all([len(d) == 2 for d in dr]))
+        self.assertEqual(start_date, dr[0][0])
+
+        dr = list(utils_proctorU_api.split_large_date_range(start_date, end_date, 34))
+        self.assertEqual(1, len(dr))
+        self.assertTrue(all([len(d) == 2 for d in dr]))
+
+        dr = list(utils_proctorU_api.split_large_date_range(start_date, end_date, 200))
+        self.assertEqual(1, len(dr))
+        self.assertEqual(end_date, dr[-1][1])

--- a/backoffice/views/courses_views.py
+++ b/backoffice/views/courses_views.py
@@ -151,8 +151,11 @@ def verified(request, course_key_string, action=None):
 
     students_grades = get_verified_student_grades(course.id)
 
+    today = datetime.datetime.today()
+    begin = today - datetime.timedelta(100)
+
     registered_users = get_proctorU_students(
-        course.id.course, course.id.run, students_grades
+        course.id.course, course.id.run, begin=begin, student_grades=students_grades
     )
 
     if "error" in registered_users:


### PR DESCRIPTION
Procotru API return a 500 error when the query timeouts, to fix this,
we perform multiples queries on smaller intervals...

This is a kind of pagination for the poor and should be done API side...

This closes #2975