### PR TITLE
backoffice: fix bug in on demand certificate generation

### DIFF
--- a/backoffice/views/users_views.py
+++ b/backoffice/views/users_views.py
@@ -143,6 +143,7 @@ def regenerate_certificate(course_id, user, certificate):
     if certificate.status != CertificateStatuses.downloadable:
         certificate.key = make_certificate_hash_key()
 
+    certificate.mode = GeneratedCertificate.MODES.honor
     certificate_filename = make_certificate_filename(course_id, key=certificate.key)
     CertificateInfo(
         user.get_profile().name, course_display_name,


### PR DESCRIPTION
We didn't fall back to honor certificate for a student once we had forced the generation of a verified certificate.
Also fix a test issue