### PR TITLE
Fix university page to display only this university's course.

### DIFF
--- a/courses/managers.py
+++ b/courses/managers.py
@@ -95,10 +95,6 @@ class CourseQuerySet(models.query.QuerySet):
     def by_score(self):
         return self.public().order_by('-score')
 
-
-class CourseManager(ChainableManager):
-    queryset_class = CourseQuerySet
-
     def random_featured(self, limit_to=7):
         courses = self.by_score().prefetch_related("related_universities__university")[:limit_to]
         courses = list(courses)

--- a/courses/models.py
+++ b/courses/models.py
@@ -13,7 +13,7 @@ from course_modes.models import CourseMode
 from jsonfield.fields import JSONField
 
 from . import choices as courses_choices
-from .managers import CourseSubjectManager, CourseManager
+from .managers import CourseSubjectManager, CourseQuerySet
 
 
 def localize_date(date_time):
@@ -63,7 +63,7 @@ class Course(models.Model):
     certificate_passing_grade = models.FloatField(_('verified certificate passing grade'),
         null=True, blank=True, help_text=(_('Percentage, between 0 and 1')))
 
-    objects = CourseManager()
+    objects = CourseQuerySet.as_manager()
 
     # Cache the courses that have a verified mode. This allows us to write
     # course.has_verified_mode by running just one additional sql query for all


### PR DESCRIPTION
Django changed the way Queryset are personnalized in the manager in 1.8 (https://docs.djangoproject.com/fr/1.10/releases/1.7/#calling-custom-queryset-methods-from-the-manager), we have to change the way we handle the managers.

This closes #3131