### PR TITLE
Fix custom querysets in manager.

### DIFF
--- a/universities/managers.py
+++ b/universities/managers.py
@@ -19,10 +19,6 @@ class UniversityQuerySet(models.query.QuerySet):
     def by_score(self):
         return self.order_by('-score', 'name')
 
-
-class UniversityManager(ChainableManager):
-    queryset_class = UniversityQuerySet
-
     def featured(self, limit_to=None):
         """Featured universities have a detail page and are not obsolete"""
         qs = self.not_obsolete().detail_page_enabled().with_related().by_score()

--- a/universities/models.py
+++ b/universities/models.py
@@ -8,7 +8,7 @@ from easy_thumbnails.files import get_thumbnailer
 from easy_thumbnails.exceptions import InvalidImageFormatError
 from ckeditor.fields import RichTextField
 
-from .managers import UniversityManager
+from .managers import UniversityQuerySet
 from . import choices as universities_choices
 
 
@@ -42,7 +42,7 @@ class University(models.Model):
     prevent_auto_update = models.BooleanField(
         verbose_name=_('prevent automatic update'), default=False)
 
-    objects = UniversityManager()
+    objects = UniversityQuerySet.as_manager()
 
     class Meta:
         ordering = ('-score', 'id',)

--- a/universities/tests/test_views.py
+++ b/universities/tests/test_views.py
@@ -33,3 +33,11 @@ class UniversityQuerysetsTests(TestCase):
         self.assertFalse(u3 in featured_universities)
         self.assertFalse(u4 in featured_universities)
         self.assertEqual(1, len(featured_universities))
+
+    def test_non_obsolete(self):
+        u1 = UniversityFactory.create(detail_page_enabled=True, is_obsolete=False)
+        u2 = UniversityFactory.create(detail_page_enabled=True, is_obsolete=True)
+
+        non_obsolete = models.University.objects.non_obsolete()
+        self.assertIn(u1, non_obsolete)
+        self.assertNotIn(u2, non_obsolete)


### PR DESCRIPTION
Django changed the way Queryset are personnalized in the manager in 1.8 (https://docs.djangoproject.com/fr/1.10/releases/1.7/#calling-custom-queryset-methods-from-the-manager), we have to change the way we handle the managers.