### PR TITLE
Fix T&C redirect mess

### DIFF
--- a/fun/envs/cms/common.py
+++ b/fun/envs/cms/common.py
@@ -49,8 +49,6 @@ MKTG_URLS['ROOT'] = 'http://' + LMS_BASE
 MKTG_URLS['TOS'] = '/tos'
 MKTG_URLS['PRIVACY'] = '/privacy'
 
-MIDDLEWARE_CLASSES += LEGAL_ACCEPTANCE_MIDDLEWARE
-
 # Allow all courses to use advanced components
 FEATURES['ALLOW_ALL_ADVANCED_COMPONENTS'] = True
 FEATURES['AUTH_USE_OPENID_PROVIDER'] = True

--- a/fun/middleware/__init__.py
+++ b/fun/middleware/__init__.py
@@ -1,3 +1,3 @@
-from .enforce_legal_acceptance import LegalAcceptance
+# _*_ coding: utf8 _*_
 
-__all__ = ( 'LegalAcceptance', )
+from .enforce_legal_acceptance import LegalAcceptance

--- a/fun/middleware/enforce_legal_acceptance.py
+++ b/fun/middleware/enforce_legal_acceptance.py
@@ -3,8 +3,10 @@
 conditions are published"""
 
 import re
+
 from django.conf import settings
 from django.shortcuts import redirect
+
 from payment.models import legal_acceptance
 
 DEFAULT_AGREEMENT_WHITELIST = map(
@@ -28,13 +30,9 @@ DEFAULT_AGREEMENT_WHITELIST = map(
         r"""^/?$""",
     )
 )
-def get(self, key, default):
-    return getattr(self, key) if hasattr(self, key) else default
 
-LMS_BASE = get(settings, "LMS_BASE", "")
-PROT = get(settings, "HTTPS", "off") == "on" and "s" or ""
-LMS_REDIR = LMS_BASE and ("http%s://%s/" % (PROT, LMS_BASE)) or ""
-DEFAULT_AGREEMENT_FORM = "%s/payment/terms/" % (LMS_REDIR)
+TERMS_AND_CONDITIONS_AGREEMENT = '/payment/terms/'
+
 
 def terms_accepted(func):
     """
@@ -44,23 +42,16 @@ def terms_accepted(func):
     AGREEMENT_FORM else defaults to DEFAULT_AGREEMENT_FORM
     """
     def wrapped(request, *args, **kwargs):
-
         if not legal_acceptance(request.user):
-            return redirect(
-                get(settings, "AGREEMENT_FORM", DEFAULT_AGREEMENT_FORM),
-                *args, **kwargs
-            )
+            return redirect(TERMS_AND_CONDITIONS_AGREEMENT, *args, **kwargs)
         else:
             return func(request, *args, **kwargs)
     return wrapped
 
+
 class LegalAcceptance(object):
     def __init__(self, *a, **kw):
-        self.white_list = get(
-            settings,
-            "AGREEMENT_WHITELIST",
-            DEFAULT_AGREEMENT_WHITELIST
-        )
+        self.white_list = DEFAULT_AGREEMENT_WHITELIST
 
     def is_whitelisted(self, url):
         return any(wl_url.match(url) for wl_url in self.white_list)

--- a/payment/models.py
+++ b/payment/models.py
@@ -71,13 +71,13 @@ class TermsAndConditions(models.Model):
         good_one = language in settings.LANGUAGES \
             and language \
             or DEFAULT_LANGUAGE
-        just_in_case=""
-        to_return = None,None
+        just_in_case = ("", "")
+        to_return = (None, None)
         for translated_term in self.texts.all():
             if translated_term.language == language and len(translated_term.tr_text):
                 to_return = unicode(translated_term.tr_text), translated_term.language
             if translated_term.language == DEFAULT_LANGUAGE:
-              just_in_case = unicode(translated_term.tr_text),DEFAULT_LANGUAGE
+              just_in_case = unicode(translated_term.tr_text), DEFAULT_LANGUAGE
         ## walking around ReST generating a 4.1 full html doc
         ## Accessibility
         text, lang = to_return if to_return[0] else just_in_case


### PR DESCRIPTION
Le code écrit par Julien pour forcer l'acceptation d'une nouvelle version des conditions d'utilisation pose plusieurs problèmes:
* très compliqué pour rien
* Le protocole HTTPS est écrit en dur, posant problème dans l'environnement de développement en HTTP
* les utilisateurs du studio, sont redirigés vers le lms pour valider les termes, et pas renvoyé vers le studio après


