### PR TITLE
fix(teaser): don't show video button when video missing

### DIFF
--- a/fun/utils/__init__.py
+++ b/fun/utils/__init__.py
@@ -50,10 +50,12 @@ def get_teaser(video_id):
         try:
             dm_id = re.compile(r'/([\d\w]+)\?').search(video_id).groups()[0]
         except AttributeError:
-            dm_id = ''
-    else:
+            return None
+    elif video_id:
         # FUN v1 did the stuff right
         dm_id = video_id
+    else:
+        return None
 
     return (
         '<iframe id="course-teaser" '

--- a/funsite/templates/lms/courseware/course_about.html
+++ b/funsite/templates/lms/courseware/course_about.html
@@ -182,7 +182,9 @@ from funsite.utils import is_paid_course
                     % if fun_course.has_verified_course_mode:
                     <span class="verified"></span>
                     % endif
+                    % if ${get_course_about_section(request, course, "video")}:
                     <div class="video-button"></div>
+                    % endif
                     <img src="${ fun_course.get_thumbnail_url('about') }" class="img-responsive">
                 </div>
 


### PR DESCRIPTION
The creator of a course can link a teaser in Studio. This saves a youtube url in Mongodb. 
This behavior was hacked to allow creators to enter dailymotion IDs and rebuild Dailymotion urls from the Youtube url. 
This backfires when the user does not enter any ID in Studio. 
This quick fix aims to hide the video button in this case and avoid building a DM url pointing to nothing.