### PR TITLE
fix(proctoru): extend validity of proctoru registration

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ hashids==1.1.0
 google-api-python-client==1.5.1
 
 # Proctoru
--e git+https://github.com/openfun/ProctorU-xBlock.git@fun-1.1.1#egg=proctoru-xblock
+-e git+https://github.com/openfun/ProctorU-xBlock.git@fun-1.1.2#egg=proctoru-xblock
 
 # Glowbl
 -e git+https://github.com/openfun/xblock-Glowbl.git@master#egg=fun-glowbl-xblock


### PR DESCRIPTION
Validation by Proctoru after registration sometimes takes more than 59 minutes and this generates a lot of support requests to reactivate the student's proctoru registration.
The timeout was bumped to 240 minutes in the Proctoru Xblock so let's update our dependencies to get it.

Planio #3991