### PR TITLE
Rework search results ordering as per d2rp recommandations

### DIFF
--- a/course_pages/templates/course_pages/index.html
+++ b/course_pages/templates/course_pages/index.html
@@ -111,8 +111,8 @@ from courses_api.routers import CourseAPIRouter
                 this.criterioncollection = options.criterioncollection;
                 this.filter = options.filter;
             	this.timeout_handle=null;
-                if (!options.filter.get("selected")) {
-                     window.history.pushState('', '', '#filter/availability/opened');
+                if (!window.location.hash) {
+                     window.history.pushState('', '', '#filter/availability/starting_soon');
                 }
             },
             search: function(query, page, rpp, sortBy) {

--- a/course_pages/tests/test_feed.py
+++ b/course_pages/tests/test_feed.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import datetime
+import pytz
 
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
@@ -19,7 +20,7 @@ from universities.tests.factories import UniversityFactory
 class FeedTest(ModuleStoreTestCase, RSSDeclarationMixin):
     def setUp(self):
         super(FeedTest, self).setUp()
-        date = datetime.datetime(2015, 1, 1, 0, 0, 0)
+        date = datetime.datetime(2015, 1, 1, 0, 0, 0, tzinfo=pytz.utc)
 
         self.url = reverse('fun-courses:feed')
         CourseFactory(org='fun', course='course1', name='item1', display_name=u"unpublished", ispublic=False)

--- a/courses/admin.py
+++ b/courses/admin.py
@@ -22,15 +22,16 @@ class CourseUniversityRelationInline(admin.TabularInline):
 
 
 class CourseAdmin(admin.ModelAdmin):
-    list_display = ('key', 'title', 'level', 'score', 'session_number',
-        'show_in_catalog', 'show_about_page', 'is_active', 'prevent_auto_update',
-        'modification_date', 'certificate_passing_grade')
-    list_filter = ('is_active', 'show_in_catalog', 'show_about_page', 'prevent_auto_update',
-        'level', 'subjects', 'universities')
-    search_fields = ('key', 'title', 'short_description',
-        'university_display_name',
+    list_display = (
+        'certificate_passing_grade', 'key', 'is_active', 'level', 'modification_date', 'title',
+        'score', 'session_number', 'show_about_page', 'show_in_catalog', 'prevent_auto_update')
+    list_filter = (
+        'is_active', 'level', 'show_in_catalog', 'show_about_page', 'prevent_auto_update',
+        'subjects', 'universities')
+    search_fields = (
         'certificateteacher_related__teacher__full_name',
-        'courseteacher_related__teacher__full_name', )
+        'courseteacher_related__teacher__full_name', 'key', 'title', 'short_description',
+        'university_display_name')
     readonly_fields = courses_settings.COURSE_ADMIN_READ_ONLY_FIELDS
     filter_horizontal = ('subjects',)
     inlines = (
@@ -91,6 +92,7 @@ class CourseSubjectAdmin(admin.ModelAdmin):
         return template.format(url=url)
     preview.short_description = _('preview')
     preview.allow_tags = True
+
 
 admin.site.register(Course, CourseAdmin)
 admin.site.register(CourseSubject, CourseSubjectAdmin)

--- a/courses/managers.py
+++ b/courses/managers.py
@@ -5,13 +5,12 @@ from django.db import connection, models
 from django.db.models import Q
 from django.utils.timezone import now, timedelta
 
-from fun.utils.managers import ChainableManager
-
 from . import settings as courses_settings
 
 
 def annotate_with_public_courses(queryset):
-    """Annotate a querysets with a public_courses_count attribute.
+    """
+    Annotate a queryset with a "public_courses_count" attribute.
 
     queryset: refer to a model with a `courses` attribute.
     """

--- a/courses/search_indexes.py
+++ b/courses/search_indexes.py
@@ -10,10 +10,13 @@ from xmodule.modulestore.django import modulestore
 
 from .models import Course
 
+
 # pylint: disable=W0223
 class ConfigurableElasticBackend(elasticsearch_backend.ElasticsearchSearchBackend):
-    """Override Hastack default backend to use our own ES configuration
-    as DEFAULT_SETTINGS constant is hardcoded ."""
+    """
+    Override Hastack default backend to use our own ES configuration as DEFAULT_SETTINGS
+    constant is hardcoded .
+    """
 
     DEFAULT_ANALYZER = "custom_french_analyzer"
 
@@ -24,16 +27,20 @@ class ConfigurableElasticBackend(elasticsearch_backend.ElasticsearchSearchBacken
             self.DEFAULT_SETTINGS = user_settings
 
     def build_schema(self, fields):
-        """This will affect DEFAULT_ANALYZER to all fields of type string if there are no other
-        analyzer explicitly defined."""
-
+        """
+        This will affect DEFAULT_ANALYZER to all fields of type string if there are no other
+        analyzer explicitly defined.
+        """
         content_field_name, mapping = super(ConfigurableElasticBackend, self).build_schema(fields)
         for _field_name, field_class in fields.items():
             field_mapping = mapping[field_class.index_fieldname]
 
             if field_mapping['type'] == 'string' and field_class.indexed:
-                if not hasattr(field_class, 'facet_for') and not field_class.field_type in('ngram', 'edge_ngram'):
-                    field_mapping['analyzer'] = getattr(field_class, 'analyzer', self.DEFAULT_ANALYZER)
+                if (
+                        not hasattr(field_class, 'facet_for') and
+                        field_class.field_type not in ('ngram', 'edge_ngram')):
+                    field_mapping['analyzer'] = getattr(
+                        field_class, 'analyzer', self.DEFAULT_ANALYZER)
             mapping.update({field_class.index_fieldname: field_mapping})
         return (content_field_name, mapping)
 
@@ -43,8 +50,10 @@ class ConfigurableElasticSearchEngine(elasticsearch_backend.ElasticsearchSearchE
 
 
 class CourseIndex(indexes.SearchIndex, indexes.Indexable):
-    """Build the document containing information we want to index from
-    Course model."""
+    """
+    Build the document containing information we want to index from
+    Course model.
+    """
     text = indexes.CharField(document=True, use_template=True)
 
     def get_model(self):
@@ -54,9 +63,11 @@ class CourseIndex(indexes.SearchIndex, indexes.Indexable):
         return self.get_model().objects.public()
 
     def prepare(self, instance):
-        """As course syllabus is store in Mongo we retrieve it and happend to
+        """
+        As course syllabus is store in Mongo we retrieve it and happend to
         document created from Course model fields in
-        courses/templates/search/indexes/courses/course_text.txt"""
+        courses/templates/search/indexes/courses/course_text.txt
+        """
         self.prepared_data = super(CourseIndex, self).prepare(instance)
 
         usage_key = CourseKey.from_string(instance.key).make_usage_key('about', 'overview')

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -7,9 +7,9 @@ from django.core.management import call_command
 
 @shared_task
 def update_courses_meta_data(*args, **kwargs):
-    '''
+    """
     A task that serves as proxy to the management command.
     Can be used for instance when a signal is fired to update
     a single course or to run periodic tasks.
-    '''
+    """
     call_command('update_courses', *args, **kwargs)

--- a/courses/tests/factories.py
+++ b/courses/tests/factories.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
 
+from datetime import datetime, timedelta
+import pytz
+from random import randint, randrange
+
+from django.utils import timezone
+
 import factory
 from factory import fuzzy
 
@@ -20,11 +26,65 @@ class CourseSubjectFactory(factory.DjangoModelFactory):
 
 
 class CourseFactory(factory.DjangoModelFactory):
+
     key = factory.Sequence('test/course-{0}'.format)
+    show_in_catalog = fuzzy.FuzzyChoice((True, False))
+
     is_active = True
 
     class Meta(object):
         model = models.Course
+
+    @factory.lazy_attribute
+    def start_date(self):
+        """
+        A start date for the course is chosen randomly in the future (it can
+        also be forced), then the other significant dates for the course are
+        chosen randomly in periods that make sense with this start date.
+        """
+        now = timezone.now()
+        period = timedelta(days=1000)
+        return pytz.timezone('UTC').localize(datetime.fromordinal(randrange(
+            now.toordinal(), (now + period).toordinal())))
+
+    @factory.lazy_attribute
+    def end_date(self):
+        """
+        The end date is at a random duration after the start date.
+        """
+        if not self.start_date:
+            return None
+        period = timedelta(days=90)
+        return pytz.timezone('UTC').localize(datetime.fromordinal(randrange(
+            self.start_date.toordinal(), (self.start_date + period).toordinal())))
+
+    @factory.lazy_attribute
+    def enrollment_start_date(self):
+        """
+        The start of enrollment date is a random date before the start date.
+        """
+        if not self.start_date:
+            return None
+        period = timedelta(days=90)
+        return pytz.timezone('UTC').localize(datetime.fromordinal(randrange(
+            (self.start_date - period).toordinal(), self.start_date.toordinal())))
+
+    @factory.lazy_attribute
+    def enrollment_end_date(self):
+        """
+        The end of enrollment date is a random date between the start of enrollment date
+        and the end of course date.
+
+        If the enrollment start date and end date have been forced to incoherent dates,
+        then just don't set any end of enrollment date...
+        """
+        if not self.start_date:
+            return None
+        end_date = self.end_date or self.start_date + timedelta(days=randint(1, 90))
+        if end_date < self.enrollment_start_date:
+            return None
+        return pytz.timezone('UTC').localize(datetime.fromordinal(randrange(
+            self.enrollment_start_date.toordinal(), end_date.toordinal())))
 
 
 class CourseUniversityRelationFactory(factory.DjangoModelFactory):

--- a/courses/tests/test_managers.py
+++ b/courses/tests/test_managers.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+
+from random import randint
+
+from django.test import TestCase
+from django.utils.timezone import now, timedelta
+
+from universities.tests.factories import UniversityFactory
+
+from ..models import Course
+from .factories import CourseFactory, CourseUniversityRelationFactory
+
+
+class CourseManagerTestCase(TestCase):
+
+    def test_courses_manager_university_courses_public(self):
+        """
+        The "public" query appended to the query to get a university's courses
+        should return only public courses for this university.
+        """
+        # Create 2 universities
+        university1, university2 = UniversityFactory.create_batch(
+            2, detail_page_enabled=True, is_obsolete=False, score=1)
+
+        # Create public courses for each university and both
+        course_u1, course_u2, course_u1u2 = CourseFactory.create_batch(
+            3, show_in_catalog=True)
+        # ... and link courses to university 1
+        CourseUniversityRelationFactory(course=course_u1, university=university1)
+        CourseUniversityRelationFactory(course=course_u2, university=university2)
+        CourseUniversityRelationFactory(course=course_u1u2, university=university1)
+        CourseUniversityRelationFactory(course=course_u1u2, university=university2)
+
+        # Create private courses for each university and both
+        course_pu1, course_pu2, course_pu1u2 = CourseFactory.create_batch(
+            3, show_in_catalog=False)
+        # ... and link courses to university 2
+        CourseUniversityRelationFactory(course=course_pu1, university=university1)
+        CourseUniversityRelationFactory(course=course_pu2, university=university2)
+        CourseUniversityRelationFactory(course=course_pu1u2, university=university1)
+        CourseUniversityRelationFactory(course=course_pu1u2, university=university2)
+
+        self.assertEqual(set(university1.courses.all()), {
+            course_u1, course_u1u2, course_pu1, course_pu1u2})
+        self.assertEqual(set(university2.courses.all()), {
+            course_u2, course_u1u2, course_pu2, course_pu1u2})
+
+        self.assertEqual(set(university1.courses.public()), {course_u1, course_u1u2})
+        self.assertEqual(set(university2.courses.public()), {course_u2, course_u1u2})
+
+    def test_courses_manager_annotate_for_ordering_course_has_ended(self):
+        """
+        A course that has ended should be annotated with a "has_ended" flag set to True.
+        """
+        past = now() - timedelta(minutes=1)
+        CourseFactory(start_date=past - timedelta(days=30), end_date=past)
+        query = Course.objects.annotate_for_ordering()
+        self.assertEqual(query[0].has_ended, True)
+
+    def test_courses_manager_annotate_for_ordering_course_has_ended_no_end(self):
+        """
+        A course with no end date should be annotated with a "has_ended" flag set to True.
+        """
+        CourseFactory(end_date=None)
+        query = Course.objects.annotate_for_ordering()
+        self.assertEqual(query[0].has_ended, False)
+
+    def test_courses_manager_annotate_for_ordering_course_has_not_ended(self):
+        """
+        A course that has not ended yet should be annotated with a "has_ended" flag set to False.
+        """
+        future = now() + timedelta(minutes=1)
+        CourseFactory(start_date=future - timedelta(days=30), end_date=future)
+        query = Course.objects.annotate_for_ordering()
+        self.assertEqual(query[0].has_ended, False)
+
+    def test_courses_manager_annotate_for_ordering_course_enrollment_over(self):
+        """
+        A course for which enrollment is finished should be annotated with a
+        "is_enrollment_over" flag set to True.
+        """
+        past = now() - timedelta(minutes=1)
+        CourseFactory(enrollment_end_date=past)
+        query = Course.objects.annotate_for_ordering()
+        self.assertEqual(query[0].is_enrollment_over, True)
+
+    def test_courses_manager_annotate_for_ordering_course_enrollment_over_no_date(self):
+        """
+        A course with no end of enrollment date should be annotated with a
+        "is_enrollment_over" flag set to False.
+        """
+        CourseFactory(enrollment_end_date=None)
+        query = Course.objects.annotate_for_ordering()
+        self.assertEqual(query[0].is_enrollment_over, False)
+
+    def test_courses_manager_annotate_for_ordering_course_enrollment_not_over(self):
+        """
+        A course for which the enrollment period is not finished yet should be annotated
+        with a "is_enrollment_over" flag set to False.
+        """
+        future = now() + timedelta(minutes=1)
+        CourseFactory(enrollment_end_date=future)
+        query = Course.objects.annotate_for_ordering()
+        self.assertEqual(query[0].is_enrollment_over, False)
+
+    def test_courses_manager_annotate_for_ordering_start_date_past_ordering_date(self):
+        """
+        A course for which the start date is in the past should be annotated with an
+        ordering date equal to its end of enrollment date.
+        """
+        past = now() - timedelta(minutes=1)
+        course = CourseFactory(start_date=past)
+        query = Course.objects.annotate_for_ordering()
+        # ordering_date is in raw SQL format. It's good enough for ordering but we ignore
+        # milliseconds before comparing them to django datetimes as they trunk milliseconds
+        # when they are equal to 0.
+        self.assertEqual(
+            query[0].ordering_date[:19], course.enrollment_end_date.strftime('%Y-%m-%d %H:%M:%S'))
+
+    def test_courses_manager_annotate_for_ordering_start_date_future_ordering_date(self):
+        """
+        A course for which the start date is in the future should be annotated with an
+        ordering date equal to its start date.
+        """
+        future = now() + timedelta(minutes=1)
+        course = CourseFactory(start_date=future)
+        query = Course.objects.annotate_for_ordering()
+        # ordering_date is in raw SQL format. It's good enough for ordering but we ignore
+        # milliseconds before comparing them to django datetimes as they trunk milliseconds
+        # when they are equal to 0.
+        self.assertEqual(
+            query[0].ordering_date[:19], course.start_date.strftime('%Y-%m-%d %H:%M:%S'))
+
+    def test_courses_manager_annotate_for_ordering_no_start_date_ordering_date(self):
+        """
+        A course for which the start date is not defined should be annotated with an ordering
+        date equal to its end of enrollment date.
+        """
+        course = CourseFactory(
+            start_date=None, enrollment_end_date=now() + timedelta(days=randint(0, 30)))
+        query = Course.objects.annotate_for_ordering()
+        # ordering_date is in raw SQL format. It's good enough for ordering but we must ignore
+        # milliseconds before comparing them to django datetimes as they trunk milliseconds
+        # when they are equal to 0.
+        self.assertEqual(
+            query[0].ordering_date[:19], course.enrollment_end_date.strftime('%Y-%m-%d %H:%M:%S'))
+
+    def test_courses_manager_annotate_for_ordering_apply(self):
+        """
+        Ordering applied on the annotated field "ordering_date" should work as expected.
+        """
+        # Create some dates:
+        #   - the name indicates if they are in the past or in the future,
+        #   - the index indicates how these 8 dates are ordered: 1 first, 8 last.
+        past3, past2, past1 = (now() - timedelta(minutes=i+1) for i in range(3))
+        future4, future5, future6, future7, future8 = (
+            now() + timedelta(minutes=i+1) for i in range(5))
+
+        # Create courses with a start date in the future and with a different ordering
+        # on the enrollment end date
+        course_a = CourseFactory(start_date=future4, enrollment_end_date=future6)
+        course_b = CourseFactory(start_date=future6, enrollment_end_date=future5)
+        course_c = CourseFactory(start_date=future7, enrollment_end_date=past1)
+
+        # Create courses with a start date in the future and with a different ordering
+        # on the enrollment end date
+        course_d = CourseFactory(start_date=past1, enrollment_end_date=future8)
+        course_e = CourseFactory(start_date=past2, enrollment_end_date=past3)
+        course_f = CourseFactory(start_date=past3, enrollment_end_date=future5)
+
+        ordered_courses = Course.objects.annotate_for_ordering().order_by('ordering_date')
+        self.assertEqual(list(ordered_courses), [
+            course_e, course_a, course_f, course_b, course_c, course_d])

--- a/courses/tests/test_models.py
+++ b/courses/tests/test_models.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from django.test import TestCase
-from django.utils.timezone import now, timedelta
 
 from courses import managers
 from courses import models
 
 from . import factories
-from universities.tests.factories import UniversityFactory
 
 
 class TestCourseSubject(TestCase):
@@ -78,59 +76,5 @@ class TestCourseSubject(TestCase):
         # database.
         with self.assertNumQueries(4):
             for course in models.Course.objects.with_related():
-                _first_university = course.get_first_university()
-                _university_name = course.university_name
-
-    def test_annotate_with_status(self):
-        yesterday = now() - timedelta(days=1)
-        tomorrow = now() + timedelta(days=1)
-        course_enrollment_ended = factories.CourseFactory.create(enrollment_end_date=yesterday)
-        course_enrollment_not_ended = factories.CourseFactory.create(enrollment_end_date=tomorrow)
-        course_open = factories.CourseFactory.create(enrollment_end_date=None)
-        queryset = models.Course.objects.annotate_with_status()
-
-        # Note: we do not use assertTrue and assertFalse here because we want
-        # to make sure is_enrollment_over is not None
-        self.assertEqual(True, queryset.get(id=course_enrollment_ended.id).is_enrollment_over)
-        self.assertEqual(False, queryset.get(id=course_enrollment_not_ended.id).is_enrollment_over)
-        self.assertEqual(False, queryset.get(id=course_open.id).is_enrollment_over)
-
-
-class TestCourseManager(TestCase):
-    def setUp(self):
-        self.u1 = UniversityFactory.create(detail_page_enabled=True, is_obsolete=False, score=1)
-        self.u2 = UniversityFactory.create(detail_page_enabled=True, is_obsolete=False, score=1)
-
-    def test_university_public_courses_should_contain_only_public_courses(self):
-        course_public = factories.CourseFactory.create()
-        course_private = factories.CourseFactory.create(show_in_catalog=False)
-        factories.CourseUniversityRelationFactory(course=course_public, university=self.u1)
-        factories.CourseUniversityRelationFactory(course=course_private, university=self.u1)
-
-        self.assertIn(course_public, self.u1.courses.public())
-        self.assertNotIn(course_private, self.u1.courses.public())
-        self.assertIn(course_public, self.u1.courses.all())
-        self.assertIn(course_private, self.u1.courses.all())
-
-    def test_public_courses_from_one_university_should_only_contain_courses_from_this_university(self):
-        course_u1 = factories.CourseFactory.create()
-        course_u1u2 = factories.CourseFactory.create()
-        course_u2 = factories.CourseFactory.create()
-
-        factories.CourseUniversityRelationFactory(course=course_u1, university=self.u1)
-        factories.CourseUniversityRelationFactory(course=course_u2, university=self.u2)
-        factories.CourseUniversityRelationFactory(course=course_u1u2, university=self.u1)
-        factories.CourseUniversityRelationFactory(course=course_u1u2, university=self.u2)
-
-        self.assertIn(course_u1, self.u1.courses.public())
-        self.assertIn(course_u1u2, self.u1.courses.public())
-
-        self.assertIn(course_u2, self.u2.courses.public())
-        self.assertIn(course_u1u2, self.u2.courses.public())
-
-        self.assertNotIn(course_u2, self.u1.courses.public())
-        self.assertNotIn(course_u1, self.u2.courses.public())
-
-        self.assertEqual(set(self.u1.courses.all()), set(self.u1.courses.public()))
-        self.assertEqual(set(self.u2.courses.all()), set(self.u2.courses.public()))
-
+                course.get_first_university()
+                course.university_name

--- a/courses/utils.py
+++ b/courses/utils.py
@@ -26,7 +26,8 @@ def get_about_section(course_descriptor, field):
 
 
 def sort_courses(courses):
-    """Sort courses in a usefull order for user:
+    """
+    Sort courses in a usefull order for user:
         - courses with enrollement date started should be first
         - then course to start to enroll should be ordered by enrollement start date (asc)
         - then course which started should be sorted by days to go (desc) or by start date asc

--- a/courses_api/filters.py
+++ b/courses_api/filters.py
@@ -41,7 +41,8 @@ class CourseFilter(filters.BaseFilterBackend):
 
         if full_text_query:
             results = SearchQuerySet().filter(content=full_text_query)
-            queryset = queryset.filter(pk__in=[item.pk for item in results.filter(django_ct='courses.course')])
+            queryset = queryset.filter(
+                pk__in=[item.pk for item in results.filter(django_ct='courses.course')])
 
         # A sorting that makes sense depends on which filter is applied
         queryset = queryset.annotate_for_ordering()

--- a/courses_api/filters.py
+++ b/courses_api/filters.py
@@ -44,13 +44,11 @@ class CourseFilter(filters.BaseFilterBackend):
             queryset = queryset.filter(pk__in=[item.pk for item in results.filter(django_ct='courses.course')])
 
         # A sorting that makes sense depends on which filter is applied
-        queryset = queryset.annotate_with_status()
-        if 'enrollment_ending_soon' in availability or 'started' in availability:
-            order_param = 'end_date'
-        elif 'archived' in availability:
+        queryset = queryset.annotate_for_ordering()
+        if 'archived' in availability:
             order_param = '-end_date'
         else:
-            order_param = 'start_date'
+            order_param = 'ordering_date'
 
         queryset = queryset.order_by('has_ended', 'is_enrollment_over', order_param)
 


### PR DESCRIPTION
This PR is an answer to D2RP request for improvement in the ordering of search results.

- "First session" and "Open for Enrollment" filters : if a course has started its date of end of enrollment should be used for ordering, otherwise its start date should be used.
- No filter applied or search by query or filter by subject or filter by organization or fiter by language: same but courses that are closed for enrollment and courses that are archived should always come last.
- Imminent end of enrollment: should be ordered by date of end of enrollment instead of end of course.
- Already started: should be ordered by date of end of enrollment instead of end of course. Courses that are closed for enrollment should come last.
- External links to a page already filtered should be respected. For the moment they are redirected to the filter "open".

- By default, filter by "starting soon" instead of "open"
