### PR TITLE
🐛(funsite) escape user's self entered fields to prevent XSS

### DIFF
--- a/funsite/templates/funsite/parts/menu.html
+++ b/funsite/templates/funsite/parts/menu.html
@@ -4,6 +4,7 @@
 
 <%!
 from django.core.urlresolvers import reverse
+from django.utils.html import escape
 from django.utils.translation import ugettext as _
 %>
 
@@ -57,7 +58,7 @@ from django.utils.translation import ugettext as _
                 <img class="user-icon" src="${static.url('funsite/images/icones/user.png')}" alt="User icon">
             </a>
             <a class="dashboard-user-link header-block no-decoration" href="${reverse('dashboard')}">
-                <span class="username color-fun-white">${request.user.profile.name}</span>
+                <span class="username color-fun-white">${escape(request.user.profile.name)}</span>
             </a>
             <a href="#" class="toggle-dropdown-menu header-block no-decoration" aria-haspopup="true">
                 <span class="vertical-arrow color-fun-white">▾</span>

--- a/payment/templates/payment/email/bill.html
+++ b/payment/templates/payment/email/bill.html
@@ -1,5 +1,6 @@
 <%page args="order, course" />
 <%!
+from django.utils.html import escape
 from django.utils.translation import ugettext as _
 
 from payment.utils import format_date_order
@@ -14,7 +15,7 @@ from payment.utils import format_date_order
 <td width="50%" colspan="2" style="font-family: monospace; font-size: 12px; border: 1px solid #555; padding: 8px">
     ${_(u"Date:" )} ${format_date_order(order, _('%m/%d/%y %H:%M'))}<br>
     ${_(u"Order No:")} ${order['number']}<br>
-    ${_(u"Contact:")} <span class="user-full-name">${user.profile.name or user.email}</span><br>
+    ${_(u"Contact:")} <span class="user-full-name">${escape(user.profile.name) or escape(user.email)}</span><br>
 </td>
 </tr>
 


### PR DESCRIPTION
Fullname and email a freely entered by user and are not verified for
special characters by form in dogwood.
This could lead to XSS exploit when rendered in mako templates which do
not escape strings as default.