### PR TITLE
🔖(minor) bump version to 4.35.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 4.18.0
+version = 4.35.0
 description = FUN MOOC applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)
@@ -32,18 +32,11 @@ install_requires =
     django-masquerade==1.3
     django-solo==1.0.3
     easy-thumbnails==2.2
-    edx-gea==0.2.0
-    glowbl-xblock==0.2.0
     oauth2client==3.0.0
     google-api-python-client==1.5.1
     hashids==1.1.0
-    libcast-xblock==0.5.0
-    password-container-xblock==0.3.0
-    proctoru-xblock==1.2.0
     pycaption==0.4.6
-    raven==5.25.0
     unicodecsv==0.9.4
-    xblock-utils2==0.3.0
 packages = find:
 zip_safe = False
 


### PR DESCRIPTION
## fun-apps 4.35.0

We've missed previous releases, this work is an attempt to get the `4.35.0` release package published.

We've checked all dependencies to sync them with the requirements files.

:warning: **Remember that both the `setup.cfg` and requirements files should be updated when upgrading a dependency.**

Non-direct dependencies have also been removed. Some of them are related to our OpenEdx instance, not `fun-apps`.