### PR TITLE
Add missing base migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+ARG EDXAPP_TAG=dogwood.3-1.0.0
+
+
+# === BASE ===
+FROM fundocker/edxapp:${EDXAPP_TAG}
+
+ARG DOCKER_UID=1000
+ARG DOCKER_GID=1000
+
+USER root:root
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+      libsqlite3-dev \
+      mongodb && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid ${DOCKER_GID} edx || \
+      echo "Group with ID ${DOCKER_GID} already exists." && \
+    useradd \
+      --create-home \
+      --home-dir /home/edx \
+      --uid ${DOCKER_UID} \
+      --gid ${DOCKER_GID} \
+      edx
+
+# To prevent permission issues related to the non-priviledged user running in
+# development, we will install development dependencies in a python virtual
+# environment belonging to that user
+RUN pip install virtualenv
+
+# Create the virtualenv directory where we will install python development
+# dependencies
+RUN mkdir -p /edx/app/edxapp/venv && \
+    chown -R ${DOCKER_UID}:${DOCKER_GID} /edx/app/edxapp/venv
+
+# Change edxapp directory owner to allow the development image docker user to
+# perform installations from edxapp sources (yeah, I know...)
+RUN chown -R ${DOCKER_UID}:${DOCKER_GID} /edx/app/edxapp
+
+# Copy the entrypoint that will activate the virtualenv
+COPY ./scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# Switch to an un-privileged user matching the host user to prevent permission
+# issues with volumes (host folders)
+USER ${DOCKER_UID}:${DOCKER_GID}
+
+# Create the virtualenv with a non-priviledged user
+RUN virtualenv -p python2.7 --system-site-packages /edx/app/edxapp/venv
+
+# Copy fun-apps sources
+COPY --chown=${DOCKER_UID}:${DOCKER_GID} . /edx/app/fun
+
+# Install fun-apps in editable mode
+RUN cd /edx/app/fun && \
+      bash -c "source /edx/app/edxapp/venv/bin/activate && \
+               pip install -e . "
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
+

--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ that can be safely updated _via_:
 $ ./scripts/manifest.sh > MANIFEST.in
 ```
 
+### Add missing migrations
+
+A shell script using Docker can be used to generate missing migrations for
+`fun-apps`:
+
+```
+$ ./scripts/migrations.sh
+```
+
+By default, migrations will be generated using the `dogwood.3` openedx release
+(using `fundocker/dogwood.3-1.0.0` base Docker image). You can override this
+default by providing a different `EDXAPP_TAG` as a script argument:
+
+```
+$ ./scripts/migrations.sh eucalyptus.3-1.0.0
+```
+
 ## License
 
 The fun-apps code is licensed under the [AGPL

--- a/courses/migrations/0008_auto_20191016_0452.py
+++ b/courses/migrations/0008_auto_20191016_0452.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('courses', '0007_auto_20190403_1113'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='course',
+            name='is_active',
+            field=models.BooleanField(default=False, verbose_name='active'),
+        ),
+        migrations.AlterField(
+            model_name='course',
+            name='language',
+            field=models.CharField(default=b'fr', max_length=255, verbose_name='language', db_index=True, choices=[(b'de', 'German'), (b'en', 'English'), (b'es', 'Spanish'), (b'fr', 'French')]),
+        ),
+    ]

--- a/payment/migrations/0004_auto_20191016_0452.py
+++ b/payment/migrations/0004_auto_20191016_0452.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('payment', '0003_auto_20180705_1154'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='translatedterms',
+            name='tr_text',
+            field=models.TextField(default=b"\n.. Ce champs est dans un format ReST (comme un wiki)\n.. Ceci est un commentaire\n.. http://deusyss.developpez.com/tutoriels/Python/SphinxDoc/#LIV-G\n\n\n.. Les 4 lignes finales (honor, privacy, tos, legal)\n.. permettent la navigation dans le contrat au niveau des ancres\n.. Pri\xc3\xa8re de les ins\xc3\xa9rer avant les titres correspondant\n.. honor = Charte utilisateurs\n.. privacy = Politique de confidentialit\xc3\xa9\n.. tos = Conditions g\xc3\xa9n\xc3\xa9rales d'utilisation\n.. legal =  Mentions l\xc3\xa9gales\n\n.. Ces commentaires ci dessus peuvent \xc3\xaatre retir\xc3\xa9s\n.. ils sont juste l\xc3\xa0 comme aide m\xc3\xa9moire :)\n\n\n.. _honor:\n\n.. _privacy:\n\n.. _tos:\n\n.. _legal:\n\n", verbose_name='Terms and conditions. (ReStructured Text)'),
+        ),
+    ]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# Development entrypoint
+#
+
+# Activate user's virtualenv
+source /edx/app/edxapp/venv/bin/activate
+exec "$@"

--- a/scripts/migrations.sh
+++ b/scripts/migrations.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+# The aim of this script is to generate missing initial migrations for apps
+# distributed with fun-apps.
+#
+# usage: scripts/migrations.sh [edxapp image tag]
+#
+# default: dogwood.3-1.1.0
+# example: scripts/migrations.sh eucalyptus.3-1.0.0
+
+declare EDXAPP_TAG
+declare PROJECT_DIRECTORY
+declare SETTINGS
+
+EDXAPP_TAG="${1:-dogwood.3-1.1.0}"
+PROJECT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit; pwd -P)"
+
+# Terminal colors
+declare -r COLOR_INFO='\033[0;36m'
+declare -r COLOR_RESET='\033[0m'
+declare -r COLOR_WARNING='\033[0;33m'
+
+
+function usage(){
+
+  echo -e "usage: migrations.sh [edxapp image]\\n"
+  exit 10
+}
+
+
+function get_apps(){
+
+  find "${PROJECT_DIRECTORY}" -maxdepth 2 -name "models.py" -exec dirname {} \; | sort
+}
+
+
+function generate_app_tmp_settings(){
+
+  declare apps
+  declare tmp_dir
+  declare tmp_settings
+
+  # Convert fun-apps applications from an absolute path to their name, e.g.
+  # /home/foo/projecs/fun-apps/teachers to teachers, and then convert this name
+  # to a python string list item, e.g. "'teachers',"
+  #
+  # Note that we also exclude the fun_api application as the admin model breaks
+  # management command calls.
+  apps=$(get_apps | grep -v "fun_api" | xargs -n 1 -I %% sh -c "basename %%" | sed "s/\\(.*\\)/  '\\1',/g")
+  tmp_dir="/tmp/fun_apps"
+  tmp_settings=$(mkdir -p ${tmp_dir} && mktemp -p "${tmp_dir}" --suffix ".py" "settings_XXXXXXXX")
+
+  echo "from .docker_run_production import *
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': '/tmp/db',
+    }
+}
+
+LANGUAGES = (('fr', 'Fran\xc3\xa7ais'), ('en', 'English'), ('de-de', 'Deutsch'))
+
+INSTALLED_APPS += (
+${apps}
+)
+" > "${tmp_settings}"
+
+  echo "${tmp_settings}"
+}
+
+function get_target_image(){
+
+  echo "edxapp:${EDXAPP_TAG}-fun-apps-dev"
+}
+
+function build_docker_image() {
+
+  cd "${PROJECT_DIRECTORY}" && \
+    docker build \
+      --build-arg EDXAPP_TAG="${EDXAPP_TAG}" \
+      --build-arg DOCKER_UID="$(id -u)" \
+      --build-arg DOCKER_GID="$(id -g)" \
+      -t "$(get_target_image)" \
+      .
+}
+
+function add_app_migrations(){
+
+  declare app
+  declare app_path
+
+  app_path="${1}"
+  app=$(basename "${app_path}")
+
+  echo -e "${COLOR_INFO}== ${app}${COLOR_RESET}"
+
+  # No models has been defined for this app
+  if [[ ! -s "${app_path}/models.py" && ! -d "${app_path}/models" ]]; then
+    echo -e "${COLOR_WARNING}SKIPPED: no model defined!${COLOR_RESET}"
+    return
+  fi
+
+  # Ensure the docker image exists, and compile it if required
+  if [[ $(docker images "$(get_target_image)" | wc -l) -eq 1 ]]; then
+    build_docker_image
+  fi
+
+  docker run --rm -ti \
+    -u "$(id -u):$(id -g)" \
+    -v "${PROJECT_DIRECTORY}:/edx/app/fun" \
+    -v "${SETTINGS}:/edx/app/edxapp/edx-platform/lms/envs/fun/app.py" \
+    -v "$(mktemp -d):/edx/var" \
+    -e "DJANGO_SETTINGS_MODULE=lms.envs.fun.app" \
+    "$(get_target_image)" \
+    bash -c "cd /edx/app/fun && \
+             pip install -e . && \
+             cd /edx/app/edxapp/edx-platform && \
+             python manage.py lms makemigrations ${app}"
+}
+
+# -- main --
+SETTINGS=$(generate_app_tmp_settings)
+
+echo -e "${COLOR_INFO}== SETTINGS${COLOR_RESET}"
+cat "${SETTINGS}"
+
+for app in $(get_apps); do
+  add_app_migrations "${app}"
+done

--- a/teachers/migrations/0001_initial.py
+++ b/teachers/migrations/0001_initial.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import ckeditor.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('courses', '0008_auto_20191016_0452'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CertificateTeacher',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('order', models.PositiveIntegerField(default=0, verbose_name='order')),
+                ('course', models.ForeignKey(related_name='certificateteacher_related', to='courses.Course')),
+            ],
+            options={
+                'ordering': ('order', 'id'),
+                'abstract': False,
+                'verbose_name': 'certificate teacher',
+                'verbose_name_plural': 'certificate teachers',
+            },
+        ),
+        migrations.CreateModel(
+            name='CourseTeacher',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('order', models.PositiveIntegerField(default=0, verbose_name='order')),
+                ('course', models.ForeignKey(related_name='courseteacher_related', to='courses.Course')),
+            ],
+            options={
+                'ordering': ('order', 'id'),
+                'abstract': False,
+                'verbose_name': 'course teacher',
+                'verbose_name_plural': 'course teachers',
+            },
+        ),
+        migrations.CreateModel(
+            name='Teacher',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('title', models.CharField(max_length=100, verbose_name='Title')),
+                ('full_name', models.CharField(max_length=300, verbose_name='Full name')),
+                ('slug', models.SlugField(unique=True, max_length=255, verbose_name='slug')),
+                ('profile_image', models.ImageField(upload_to=b'teachers', null=True, verbose_name='profile image', blank=True)),
+                ('bio', ckeditor.fields.RichTextField(verbose_name='bio', blank=True)),
+            ],
+            options={
+                'verbose_name': 'teacher',
+                'verbose_name_plural': 'teachers',
+            },
+        ),
+        migrations.AddField(
+            model_name='courseteacher',
+            name='teacher',
+            field=models.ForeignKey(related_name='+', to='teachers.Teacher'),
+        ),
+        migrations.AddField(
+            model_name='certificateteacher',
+            name='teacher',
+            field=models.ForeignKey(related_name='+', to='teachers.Teacher'),
+        ),
+        migrations.AlterUniqueTogether(
+            name='courseteacher',
+            unique_together=set([('course', 'teacher')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='certificateteacher',
+            unique_together=set([('course', 'teacher')]),
+        ),
+    ]

--- a/universities/migrations/0002_auto_20191016_0452.py
+++ b/universities/migrations/0002_auto_20191016_0452.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('universities', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='university',
+            options={'ordering': ('-score', 'id'), 'verbose_name': 'University', 'verbose_name_plural': 'Universities'},
+        ),
+    ]


### PR DESCRIPTION
## Purpose

When initializing a new database from an `edxapp` project with `fun_apps` installed and configured, the initial migration fails due to missing initial migrations and dependencies in `fun_apps` Django applications.

## Proposal

- [x] Add a migrations generation script
- [x] Add missing migrations