### PR TITLE
🔖(major) bump version to 5.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 4.36.0
+version = 5.0.0
 description = FUN MOOC applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION
### Added

- a new bash script has been developed to ease/automate migrations generation in an openedx context

### Fixed

- add missing migrations for the following apps:
    - courses (field verbose name and active languages)
    - payment (field verbose name)
    - teachers (initial migration)
    - university (field ordering)

:warning: **Warning** :warning: 

The teachers application migration has to be faked in production as the database schema already exists. We consider this as a **BC**, thus bumping a new major version.