### PR TITLE
Release 5.1.0

### DIFF
--- a/fun/envs/common.py
+++ b/fun/envs/common.py
@@ -401,6 +401,8 @@ ENABLE_ADWAYS_FOR_COURSES = (
     'course-v1:FUN+1000+session1',
     'course-v1:lorraine+30003+SPOC_1819_session_2',
     'course-v1:lorraine+30003+SPOC_1920_session_1',
+    'course-v1:lorraine+30003+session04',
+    'course-v1:lorraine+30003+SPOC_1920_session_2',
 )
 
 LTI_XBLOCK_CONFIGURATIONS = [

--- a/funsite/templates/funsite/parts/base.html
+++ b/funsite/templates/funsite/parts/base.html
@@ -74,9 +74,9 @@ dir_rtl = 'rtl' if get_language_bidi() else 'ltr'
 
 
 <%include file="footer.html" args="base_application='funsite'"/>
-    <script src="${static.url('funsite/jquery/dist/jquery.min.js')}"></script>
-    <script src="${static.url('funsite/bootstrap/js/bootstrap.min.js')}"></script>
-    <script src="${static.url('funsite/owl.carousel/owl.carousel.min.js')}"></script>
+    <script type="text/javascript" src="${static.url('funsite/jquery/dist/jquery.min.js')}"></script>
+    <script type="text/javascript" src="${static.url('funsite/bootstrap/js/bootstrap.min.js')}"></script>
+    <script type="text/javascript" src="${static.url('funsite/owl.carousel/owl.carousel.min.js')}"></script>
 
     <script type="text/javascript" src="/i18n.js"></script>
     <script type="text/javascript" src="${static.url('js/src/utility.js')}"></script>
@@ -86,9 +86,9 @@ dir_rtl = 'rtl' if get_language_bidi() else 'ltr'
 
 % if request.META and request.META.get("HTTP_HOST"):
     %if "fun-mooc.fr" in request.META["HTTP_HOST"]:
-        <script src="//tag.aticdn.net/602676/smarttag.js"></script>
+        <script  type="text/javascript" src="//tag.aticdn.net/602676/smarttag.js"></script>
     % else:
-        <script src="//tag.aticdn.net/602677/smarttag.js"></script>
+        <script  type="text/javascript" src="//tag.aticdn.net/602677/smarttag.js"></script>
     % endif
 % endif
     <%block name="js_extra"/>
@@ -96,21 +96,23 @@ dir_rtl = 'rtl' if get_language_bidi() else 'ltr'
 % if request.META and request.META.get("HTTP_HOST"):
     <script type="text/javascript">
         (function () {
-            // Check for presence of tracking cookie acceptation
-            var ca = document.cookie.split(';');
-            for (var i = 0; i < ca.length; i++) {
-                var c = ca[i];
-                while (c.charAt(0) == ' ') {
-                    c = c.substring(1, c.length);
-                }
-                if (c.indexOf("acceptCookieFun=") === 0) {
-                    % if "fun-mooc.fr" in request.META["HTTP_HOST"]:
-                        var tag = new ATInternet.Tracker.Tag({ site: 602676 });
-                    % else:
-                        var tag = new ATInternet.Tracker.Tag({ site: 602677 });
-                    % endif
-                    tag.page.set({});
-                    tag.dispatch();
+            if (window.ATInternet) {
+                // Check for presence of tracking cookie acceptation
+                var ca = document.cookie.split(';');
+                for (var i = 0; i < ca.length; i++) {
+                    var c = ca[i];
+                    while (c.charAt(0) == ' ') {
+                        c = c.substring(1, c.length);
+                    }
+                    if (c.indexOf("acceptCookieFun=") === 0) {
+                        % if "fun-mooc.fr" in request.META["HTTP_HOST"]:
+                            var tag = new ATInternet.Tracker.Tag({ site: 602676 });
+                        % else:
+                            var tag = new ATInternet.Tracker.Tag({ site: 602677 });
+                        % endif
+                        tag.page.set({});
+                        tag.dispatch();
+                    }
                 }
             }
         })();

--- a/funsite/templates/lms/main.html
+++ b/funsite/templates/lms/main.html
@@ -150,11 +150,12 @@ from branding import api as branding_api
 
 % if request.META and request.META.get("HTTP_HOST"):
   % if "fun-mooc.fr" in request.META["HTTP_HOST"]:
-    <script src="//tag.aticdn.net/602676/smarttag.js"></script>
+    <script  type="text/javascript" src="//tag.aticdn.net/602676/smarttag.js"></script>
   % else:
-    <script src="//tag.aticdn.net/602677/smarttag.js"></script>
+    <script  type="text/javascript" src="//tag.aticdn.net/602677/smarttag.js"></script>
   % endif
     <script type="text/javascript">
+    if (window.ATInternet) {
       % if "fun-mooc.fr" in request.META["HTTP_HOST"]:
         var tag = new ATInternet.Tracker.Tag({ site: 602676 });
       % else:
@@ -162,6 +163,7 @@ from branding import api as branding_api
       % endif
       tag.page.set({});
       tag.dispatch();
+    }
     </script>
 %endif
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 5.0.0
+version = 5.1.0
 description = FUN MOOC applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION
Next fun-mooc.fr release

note that v4.35, v4.35.1, v4.36 and v5.0.0 have not been deployed on production instance

Added:

- 2 new courses are allowed to use Adways
- add Glowbl settings to configurable_lti_consumer
- a new bash script has been developed to ease/automate migrations
   generation in an openedx context

Changed:

- wording changes related to cookie banner and about page

Fixed:

- fix a JS error with ATInternet tracker is blocked
- add missing migrations for the following apps:
    - courses (field verbose name and active languages)
    - payment (field verbose name)
    - teachers (initial migration)
    - university (field ordering)
