### PR TITLE
🔖(patch) bump release to 2.0.1+wb

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 2.0.0+wb
+version = 2.0.1+wb
 description = FUN-MOOC White Brands applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION
### Changed

- Add ProctorExam LTI Xblock (eucalyptus release) in development dependencies

### Fixed

- Fix broken payment migration 0002