### PR TITLE
🔥(videofront) set video upload panel read only

### DIFF
--- a/fun/templates/cms/videoupload/index.html
+++ b/fun/templates/cms/videoupload/index.html
@@ -128,14 +128,6 @@ from videoproviders.forms import SubtitleForm, ThumbnailForm
       ${_("Video uploads")}
       <small class="subtitle">${_("Add videos to your course")}</small>
     </h1>
-    <nav class="nav-actions" aria-label="${_('Page Actions')}">
-      <div id="upload-video-button">
-        <form id="videoupload-form">
-          <button class="button button-new"><i class="icon fa fa-plus"></i>${_('Upload new videos')}</button>
-          <input type="file" title="${_('Click to upload a new video')}" style="display: none;" multiple>
-        </form>
-      </div>
-    </nav>
   </header>
 </div>
 

--- a/fun/templates/cms/videoupload/js/parameters-subtitle.underscore
+++ b/fun/templates/cms/videoupload/js/parameters-subtitle.underscore
@@ -6,10 +6,3 @@
     </li>
   </ul>
 </td>
-<td>
-  <ul class="actions-list">
-    <li class="action-item action-delete">
-      <a class="action-button" href="#" data-tooltip="<%= gettext('Delete') %>"><i class="icon fa fa-times-circle"></i> <span class="sr"><%= gettext('Delete') %></span></a>
-    </li>
-  </ul>
-</td>

--- a/fun/templates/cms/videoupload/js/parameters.underscore
+++ b/fun/templates/cms/videoupload/js/parameters.underscore
@@ -24,23 +24,7 @@
 
     <div class="divider-visual"></div>
 
-    <div class="modal-subsection">
-      <div class="modal-subsection-title"><%= gettext("Add subtitles") %></div>
-      <div class="modal-subsection-content">
-        <div class="upload-subtitles"></div>
-      </div>
-    </div>
-
-    <div class="divider-visual"></div>
-
     <div class="thumbnail"></div>
 
-    <div class="divider-visual"></div>
-    <div class="modal-subsection">
-      <div class="modal-subsection-title"><%= gettext("Change thumbnail") %></div>
-      <div class="modal-subsection-content">
-        <div class="upload-thumbnail"></div>
-      </div>
-    </div>
   </div>
 </div>

--- a/fun/templates/cms/videoupload/js/video.underscore
+++ b/fun/templates/cms/videoupload/js/video.underscore
@@ -22,13 +22,6 @@
   <% } %>
   <input value="<%= title %>" class="togglable invisible">
 
-  <% if (status === "ready") { %>
-    <ul class="actions-list togglable">
-      <li class="action-item action-edit-title">
-        <a class="action-button" href="#" onclick="return false;" data-tooltip="<%= gettext('Edit video title') %>"><i class="icon fa fa-pencil"></i></a>
-      </li>
-    </ul>
-  <% } %>
 </td>
 <td class="created-at"><%= created_at %></td>
 <td class="id"><%= id %></td>


### PR DESCRIPTION
Remove button to upload new video and remove buttons to modify
existing videos. Still user can download existing videos, thumbails and
subtitles.