### PR TITLE
🐛(circleci) add v to the tag as it is done on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ workflows:
             - build
           filters:
             tags:
-              only: /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(\+([a-z]*))$/
+              only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(\+([a-z]*))$/
             branches:
               ignore: /.*/
 
@@ -147,6 +147,6 @@ workflows:
             - validate
           filters:
             tags:
-              only: /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(\+([a-z]*))$/
+              only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(\+([a-z]*))$/
             branches:
               ignore: /.*/


### PR DESCRIPTION
## Purpose

The release tags on all our repositories are starting with a `v.`

## Proposal

Add a v so that tags starting with a v are built, validated and deployed.