### PR TITLE
🔧(certificates) rewrite constants related to fun's PDF certificates urls

### DIFF
--- a/backoffice/certificate_manager/utils.py
+++ b/backoffice/certificate_manager/utils.py
@@ -251,5 +251,5 @@ def make_certificate_hash_key():
 
 def set_certificate_filename(certificate, filename):
     certificate.status = CertificateStatuses.downloadable
-    certificate.download_url = os.path.join(settings.CERTIFICATE_BASE_URL, filename)
+    certificate.download_url = os.path.join(settings.CERTIFICATES_DIRECTORY_NAME, filename)
     return certificate

--- a/backoffice/certificate_manager/views.py
+++ b/backoffice/certificate_manager/views.py
@@ -50,7 +50,7 @@ def certificate_dashboard(request, course_key_string):
 
     return render(request, 'backoffice/certificate.html', {
         'course': course,
-        'certificate_base_url': settings.CERTIFICATE_BASE_URL,
+        'certificates_directory': settings.CERTIFICATES_DIRECTORY_NAME,
         'instructor_tasks': instructor_tasks,
         'instructor_tasks_history': instructor_tasks_history,
     })

--- a/backoffice/templates/backoffice/certificate.html
+++ b/backoffice/templates/backoffice/certificate.html
@@ -7,7 +7,7 @@
 {% block extra_head %}
 <style>
 #generate_test_certificate_button, #generate_certificate_button, .panel {
-  margin : 15px;} 
+  margin : 15px;}
 </style>
 {% endblock %}
 
@@ -18,7 +18,7 @@
 {% block content %}
 <h2>{{ course.display_name_with_default }}</h2>
 
-<a class="btn btn-primary"  id="generate_test_certificate_button" href="{% url 'backoffice:generate-test-certificate' course.id %}" data-certificate-base-url="{{certificate_base_url}}">{% trans 'Generate test certificate' %} </a>
+<a class="btn btn-primary"  id="generate_test_certificate_button" href="{% url 'backoffice:generate-test-certificate' course.id %}" data-certificate-base-url="/media/{{certificates_directory}}">{% trans 'Generate test certificate' %} </a>
 <a class="btn btn-danger" id="generate_certificate_button" data-toggle="modal" data-target="#certificate-generation-modal">{% trans 'Generate certificates' %}</a>
 
 <!-- First Panel : pending certificate generations tasks -->
@@ -93,7 +93,7 @@
                   <td>{% if instructor_task.task_type == 'certificate-generation' %}{% trans "Non Verified" %}{% else %}{% trans "Verified" %}{% endif %}</td>
                   <td class="task-certificate-pdf">
                     {% if instructor_task.task_type == 'certificate-generation' %}
-                        <a href="{{certificate_base_url}}{{instructor_task.task_output.test_certificate_filename}}">{% trans "Sample" %}</a>
+                        <a href="/media/{{certificates_directory}}/{{instructor_task.task_output.test_certificate_filename}}">{% trans "Sample" %}</a>
                     {% endif %}
                   </td>
                   <td class="task-enrolled-students">{{instructor_task.task_output.total}}</td>

--- a/backoffice/templates/backoffice/user.html
+++ b/backoffice/templates/backoffice/user.html
@@ -79,7 +79,7 @@
                     </p>
                 </div>
             </div>
- 
+
             <div class="form-group">
                 {{ userform|bootstrap_horizontal:'col-lg-4' }}
 
@@ -213,7 +213,7 @@
                                 {% if certificate.cert.mode == 'verified' %}
                                     <a href="{% url 'short-cert-url' certificate.hashid %}" target="_blank" title="{% trans 'View verified certificate' %}"><span class='glyphicon glyphicon-bookmark'></span></a>
                                 {% else %}
-                                    <a href="{{ certificate.cert.download_url }}" title="{% trans 'Download PDF' %}"><span class='glyphicon glyphicon-download-alt'></span></a>
+                                    <a href="/media/{{ certificate.cert.download_url }}" title="{% trans 'Download PDF' %}"><span class='glyphicon glyphicon-download-alt'></span></a>
                                 {% endif %}
                             {% endif %}
 

--- a/backoffice/tests/test_certificates.py
+++ b/backoffice/tests/test_certificates.py
@@ -45,7 +45,8 @@ class CertificateTests(ModuleStoreTestCase):
         self.configure_course()
         mock_make_certificate_hash_key.return_value = "dummyhash"
         test_certificate_path = os.path.join(
-            settings.CERTIFICATES_DIRECTORY,
+            settings.MEDIA_ROOT,
+            settings.CERTIFICATES_DIRECTORY_NAME,
             "TEST_attestation_suivi_{}_dummyhash.pdf".format(unicode(self.course.id).replace("/", "_"))
         )
         if os.path.exists(test_certificate_path):

--- a/fun/envs/lms/common.py
+++ b/fun/envs/lms/common.py
@@ -136,8 +136,7 @@ FUN_SMALL_LOGO_RELATIVE_PATH = 'funsite/images/logos/funmooc173.png'
 FUN_BIG_LOGO_RELATIVE_PATH = 'funsite/images/logos/funmoocfp.png'
 
 # Certificates related settings
-CERTIFICATE_BASE_URL = '/attestations/'
-CERTIFICATES_DIRECTORY = '/edx/var/edxapp/attestations/'
+CERTIFICATES_DIRECTORY_NAME = 'attestations'
 FUN_LOGO_PATH = FUN_BASE_ROOT / 'funsite/static' / FUN_BIG_LOGO_RELATIVE_PATH
 FUN_ATTESTATION_LOGO_PATH = FUN_BASE_ROOT / 'funsite/static' / 'funsite/images/logos/funmoocattest.png'
 STUDENT_NAME_FOR_TEST_CERTIFICATE = 'Test User'

--- a/fun/lms/urls.py
+++ b/fun/lms/urls.py
@@ -68,11 +68,6 @@ urlpatterns = patterns('',
 
     # Ora2 file upload
     url(r'^openassessment/storage', include(openassessment.fileupload.urls)),
-
-    # Download pdf certificates: this is necessary when the nginx server is not
-    # available to redirect to the certificates directory, such as in development
-    # mode
-    (r'^attestations/(?P<path>.*)$', 'django.views.static.serve', {'document_root': settings.CERTIFICATES_DIRECTORY}),
 )
 
 # Ckeditor - Used by Univerity app

--- a/fun_certificates/generator.py
+++ b/fun_certificates/generator.py
@@ -71,7 +71,7 @@ class CertificateInfo(object):
 
     @property
     def pdf_file_name(self):
-        return os.path.join(settings.CERTIFICATES_DIRECTORY, self.filename)
+        return os.path.join(settings.MEDIA_ROOT, settings.CERTIFICATES_DIRECTORY_NAME, self.filename)
 
     @property
     def organizationNameTooLong(self):


### PR DESCRIPTION
This modification follows change of location of certificates files which
were previously stored in there own volume and have now been moved to
`media` volume in `certificate` directory.

Simplify constants needed to build url and use a different name for safety.