### PR TITLE
🔖(fix) bump version to 5.2.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 5.2.0
+version = 5.2.1
 description = FUN MOOC applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION
Fixed:
  - Rewrite constants related to fun's PDF certificates urls