### PR TITLE
WIP ⚡️(backoffice) improve course list view by using SQL course table

### DIFF
--- a/backoffice/templates/backoffice/courses/base-detail.html
+++ b/backoffice/templates/backoffice/courses/base-detail.html
@@ -5,7 +5,10 @@
 
 {% block content %}
 
-<h1>{{ course_info.course.display_name_with_default }}</h1>
+<h1>
+    {{ course_info.course.display_name_with_default }}
+    {% if course_info.modes %}<span class="glyphicon glyphicon-euro" aria-hidden="true"></span>{% endif %}
+</h1>
 {% if course_info.course.ispublic %}<span class="label label-success">{% trans "Published" %}</span>{% endif %}
 {% if course_info.course.is_draft %}<span class="label label-primary">{% trans "Draft" %}</span>{% endif %}
 

--- a/backoffice/templates/backoffice/courses/list.html
+++ b/backoffice/templates/backoffice/courses/list.html
@@ -49,6 +49,7 @@
                     <th>{% trans 'End' %}</th>
                     <th>{% trans 'Enrollment start' %}</th>
                     <th>{% trans 'Enrollment end' %}</th>
+                    <th>{% trans 'Enrollments' %}</th>
                     <th>{% trans 'See' %}</th>
                 </tr>
             </thead>
@@ -72,6 +73,10 @@
                     <td data-order="{{ course_info.end_date|date:'ymd' }}">{{ course_info.end_date|date:'d/m/y' }}</td>
                     <td data-order="{{ course_info.enrollment_start_date|date:'ymd' }}">{{ course_info.enrollment_start_date|date:'d/m/y' }}</td>
                     <td data-order="{{ course_info.enrollment_end_date|date:'ymd' }}">{{ course_info.enrollment_end_date|date:'d/m/y' }}</td>
+
+                    <td data-order="{{ course_info.course_enrollments }}">{{ course_info.course_enrollments }}</td>
+
+
                     <td>
                         <a target="_blank" href="//{{ lms_base }}/courses/{{ course_info.key }}/about" title="{% trans 'See course' %}"><span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span></a>
                     </td>

--- a/backoffice/templates/backoffice/courses/list.html
+++ b/backoffice/templates/backoffice/courses/list.html
@@ -49,8 +49,6 @@
                     <th>{% trans 'End' %}</th>
                     <th>{% trans 'Enrollment start' %}</th>
                     <th>{% trans 'Enrollment end' %}</th>
-                    <th>{% trans 'Enrollments' %}</th>
-                    <th>{% trans 'Mode' %}</th>
                     <th>{% trans 'See' %}</th>
                 </tr>
             </thead>
@@ -58,25 +56,24 @@
                 {% for course_info in course_infos %}
                 <tr>
                     <td>
-                        <a href="{% url 'backoffice:course-detail' course_info.course.id %}">{{ course_info.course.id }}</a>
-                        {% if course_info.course.ispublic %}<span class="label label-success">{% trans "Published" %}</span>{% endif %}
-                        {% if course_info.course.is_draft %}<span class="label label-primary">{% trans "Draft" %}</span>{% endif %}
+                        <a href="{% url 'backoffice:course-detail' course_info.key %}">{{ course_info.key }}</a>
+                        {% if course_info.show_in_catalog %}
+                            <span class="label label-success">{% trans "Visible" %}</span>
+                        {% else %}
+                            <span class="label label-primary">{% trans "Invisible" %}</span>
+                        {% endif %}
                     </td>
 
                     <td>
-                        {% if course_info.fun.university %}{{ course_info.fun.university.name }}{% else %}<span class="no-university">{{ course_info.course.org }}</span>{% endif %}
+                        {{ course_info.university_display_name }}
                     </td>
-                    <td>{{ course_info.course.display_name_with_default }}</td>
-                    <td data-order="{{ course_info.course.start|date:'ymd' }}">{{ course_info.course.start|date:'d/m/y' }}</td>
-                    <td data-order="{{ course_info.course.end|date:'ymd' }}">{{ course_info.course.end|date:'d/m/y' }}</td>
-                    <td data-order="{{ course_info.course.enrollment_start|date:'ymd' }}">{{ course_info.course.enrollment_start|date:'d/m/y' }}</td>
-                    <td data-order="{{ course_info.course.enrollment_end|date:'ymd' }}">{{ course_info.course.enrollment_end|date:'d/m/y' }}</td>
-                    <td>{{ course_info.students_count }}</td>
+                    <td>{{ course_info.title }}</td>
+                    <td data-order="{{ course_info.course.start_date|date:'ymd' }}">{{ course_info.start_date|date:'d/m/y' }}</td>
+                    <td data-order="{{ course_info.end_date|date:'ymd' }}">{{ course_info.end_date|date:'d/m/y' }}</td>
+                    <td data-order="{{ course_info.enrollment_start_date|date:'ymd' }}">{{ course_info.enrollment_start_date|date:'d/m/y' }}</td>
+                    <td data-order="{{ course_info.enrollment_end_date|date:'ymd' }}">{{ course_info.enrollment_end_date|date:'d/m/y' }}</td>
                     <td>
-                        {% if course_info.modes %}<span class="glyphicon glyphicon-euro" aria-hidden="true"></span>{% endif %}
-                    </td>
-                    <td>
-                        <a target="_blank" href="{{ course_info.url }}" title="{% trans 'See course' %}"><span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span></a>
+                        <a target="_blank" href="//{{ lms_base }}/courses/{{ course_info.key }}/about" title="{% trans 'See course' %}"><span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span></a>
                     </td>
                 </tr>
                 {% empty %}

--- a/backoffice/views/courses_views.py
+++ b/backoffice/views/courses_views.py
@@ -24,6 +24,7 @@ from student.models import CourseEnrollment, CourseAccessRole, User
 from universities.models import University
 from xmodule.modulestore.django import modulestore
 
+from courses.models import Course
 from fun.utils import funwiki as wiki_utils
 from fun.utils.export_data import csv_response
 
@@ -48,6 +49,7 @@ COURSE_FIELDS = [
 ABOUT_SECTION_FIELDS = ['effort', 'video']
 FunCourse = namedtuple('FunCourse', COURSE_FIELDS)
 CompleteFunCourse = namedtuple('CompleteFunCourse', COURSE_FIELDS + ABOUT_SECTION_FIELDS)
+
 
 @group_required('fun_backoffice')
 def courses_list(request):
@@ -74,11 +76,18 @@ def courses_list(request):
         return response
     else:
         search_pattern = request.GET.get('search')
-        course_infos = get_filtered_course_infos(search_pattern=search_pattern)
+        course_infos = Course.objects.all()
+        if search_pattern:
+            course_infos = course_infos.filter(
+                Q(title__icontains=search_pattern) |
+                Q(key__icontains=search_pattern) |
+                Q(university_display_name__icontains=search_pattern)
+            )
 
     return render(request, 'backoffice/courses/list.html', {
         'course_infos': course_infos,
         'pattern': search_pattern,
+        'lms_base': settings.LMS_BASE,
         'tab': 'courses',
     })
 


### PR DESCRIPTION
We now use FUN SQL course table to display course list instead of edX
modulestore and this is way more quick. We gave up student enrollment
count and course modes in the process, but this information is available
on detail page.