### PR TITLE
✨(videoproviders) add support for bokecc service

### DIFF
--- a/fun/cms/views/videoupload.py
+++ b/fun/cms/views/videoupload.py
@@ -35,6 +35,7 @@ def catch_missing_credentials_error(view_func):
 @catch_missing_credentials_error
 def home(request, course_key_string):
     course_module = get_course(course_key_string)
+    api_client = get_client(course_key_string)
 
     if not request.user.is_staff and not request.user.is_superuser:
         # Are we in a deactivation period?
@@ -53,6 +54,7 @@ def home(request, course_key_string):
             })
     return render_to_response('videoupload/index.html', {
         "context_course": course_module,
+        "context_api_class": api_client.__class__.__module__
     })
 
 @has_write_access_to_course

--- a/fun/templates/cms/videoupload/index.html
+++ b/fun/templates/cms/videoupload/index.html
@@ -128,6 +128,16 @@ from videoproviders.forms import SubtitleForm, ThumbnailForm
       ${_("Video uploads")}
       <small class="subtitle">${_("Add videos to your course")}</small>
     </h1>
+    % if context_api_class != 'videoproviders.api.bokecc':
+        <nav class="nav-actions" aria-label="${_('Page Actions')}">
+        <div id="upload-video-button">
+            <form id="videoupload-form">
+              <button class="button button-new"><i class="icon fa fa-plus"></i>${_('Upload new videos')}</button>
+              <input type="file" title="${_('Click to upload a new video')}" style="display: none;" multiple>
+            </form>
+          </div>
+        </nav>
+    % endif
   </header>
 </div>
 

--- a/fun/templates/cms/videoupload/js/video.underscore
+++ b/fun/templates/cms/videoupload/js/video.underscore
@@ -13,6 +13,9 @@
     <% } %>
   </video>
   <% } %>
+  <% if (prev_image.length > 0) {%>
+    <img src="<%= prev_image %>"  width="350" height="197">
+  <% } %>
 </td>
 <td class="title">
   <% if (external_link.length > 0) { %>
@@ -43,14 +46,14 @@
     </li>
     <% } %>
 
-    <% if (status === "created" || status === "ready") { %>
+    <% if (can_parametrize && (status === "created" || status === "ready")) { %>
     <li class="action-item action-parameters">
       <!-- <i class="icon fa fa-cog"></i> -->
       <a class="action-button" href="#" onclick="return false;" data-tooltip="<%= gettext('Parameters') %>"><i class="icon fa fa-cog"></i> <span class="sr"><%= gettext('Parameters') %></span></a>
     </li>
     <% } %>
 
-    <% if (status !== "uploading" && status !== "deleted") { %>
+    <% if (can_delete && (status !== "uploading" && status !== "deleted")) { %>
     <li class="action-item action-delete">
       <a class="action-button" href="#" onclick="return false;" data-tooltip="<%= gettext('Delete this video') %>"><i class="icon fa fa-times-circle"></i> <span class="sr"><%= gettext('Delete this video') %></span></a>
     </li>

--- a/fun/templates/cms/videoupload/js/videoupload.js
+++ b/fun/templates/cms/videoupload/js/videoupload.js
@@ -1,3 +1,8 @@
+/**
+ * Video upload library
+ **/
+
+/*
 <%!
 from django.utils.translation import ugettext as _
 %>
@@ -10,6 +15,7 @@ def reverse_course(handler_name, kwargs=None):
   return reverse(handler_name, kwargs=kwargs)
 %>
 <%namespace name='static' file='../../static_content.html'/>
+*/
 
 require(["jquery", "underscore", "backbone", "gettext",
          "js/utils/templates", "js/views/modals/base_modal", "common/js/components/views/feedback_notification",
@@ -172,6 +178,8 @@ require(["jquery", "underscore", "backbone", "gettext",
         if (!values.id) {
             values.id = "";
         }
+        values.can_delete =  true;
+        values.can_parametrize =  ( '${context_api_class}' !== 'videoproviders.api.bokecc' );
         this.$el.html(this.template(values));
         if (!values.embed_url && values.video_sources && values.video_sources.length > 0) {
           // Time to activate the video player

--- a/requirements/base_wb.txt
+++ b/requirements/base_wb.txt
@@ -15,7 +15,6 @@ hashids==1.1.0
 #-e git+https://github.com/openfun/xblock-utils2.git@master#egg=xblockutils2
 
 # Video
--e git+https://github.com/openfun/libcast-xblock.git@0.4.5#egg=libcast-xblock
 google-api-python-client==1.5.1
 
 # Carousel
@@ -26,6 +25,7 @@ google-api-python-client==1.5.1
 
 # Configurable LTI consumer xblock
 exrex==0.10.5
+libcast-xblock==0.6.0
 xblock-configurable-lti-consumer==1.2.4+eucalyptus
 
 # Proctor Exam xblock

--- a/videoproviders/api/__init__.py
+++ b/videoproviders/api/__init__.py
@@ -2,8 +2,9 @@ import importlib
 
 from .base import MissingCredentials, ClientError
 
+from django.conf import settings
 
-VIDEO_CLIENT_MODULE = "videoproviders.api.videofront"
+VIDEO_CLIENT_MODULE = getattr(settings, 'DEFAULT_VIDEO_CLIENT_MODULE', 'videoproviders.api.videofront')
 VIDEO_CLIENT_CLASS = "Client"
 
 

--- a/videoproviders/api/bokecc.py
+++ b/videoproviders/api/bokecc.py
@@ -1,0 +1,299 @@
+import json
+import logging
+import re
+import time
+import urllib
+
+from django.conf import settings
+
+from .base import BaseClient, ClientError, MissingVideo
+from ..models import BokeCCCourseSettings
+
+logger = logging.getLogger(__name__)
+
+
+class Client(BaseClient):
+    """
+    This is the client for the Bokecc video provider.
+    There is only one account per platform's instance. Video are stored under
+    different categories representing each university
+    """
+
+    def __init__(self, course_key_string):
+        super(Client, self).__init__(course_key_string)
+        self.course_key_string = course_key_string
+        self._playlist_id = None
+
+    @property
+    def playlist_id(self):
+        # The concept of 'playlist' will be used to split videos from different courses
+        # However there are limitations due to the fact that playlists are limited to 100 elements
+        if self._playlist_id is None:
+            # Build the playlist if from the course_key_string and check if any
+            # Bokecc playlist exists with this name
+            self._playlist_id = BokeccUtil.get_or_create_playlist(self.course_id)
+        return self._playlist_id
+
+    ####################
+    # Overridden methods
+    ####################
+
+    def get_auth(self):
+        # Here there is no specific Auth credentials except the ones provided in the general
+        # Settings (see BOKECC_APIKEY and BOKECC_USERID)
+        api_salt_key, user_id = BokeccUtil.get_auth()
+        return {"user_id": user_id, "salt_key": api_salt_key}
+
+    def get_video(self, video_id, player_width="890px", player_height="375px"):
+        """Return a single video, identified by its id."""
+        video = {}
+        # Get video info - playcode :
+        # {
+        #     "video": {
+        #         "playcode":"<script src='xxx' ...</script>"
+        #     }
+        # }
+        bokecc_video_playcode = BokeccUtil.bokecc_request_get(
+            'video/playcode',
+            params={'videoid': video_id,
+                    'playerid': BokeccUtil.BOKECC_PLAYER_ID,
+                    'auto_play': 'false',
+                    'player_width': player_width,
+                    'player_height': player_height}
+        )
+        # Get video info - Format :
+        # {
+        #     "video": {
+        #         "id": "XXX",
+        #         "title": "TITLKE",
+        #         "desp": "DESC",
+        #         "tags": " ",
+        #         "duration": 10,
+        #         "category": "YYY",
+        #         "image": "http://img.bokecc.com/comimage/XXXXX",
+        #         "imageindex": 0,
+        #         "image-alternate": [
+        #             {
+        #                 "index": 0,
+        #                 "url": "ZZZZ"
+        #             },
+        #         ]
+        #     }
+        # }
+        bokecc_video_infos = BokeccUtil.bokecc_request_get(
+            'video',
+            params={'videoid': video_id, }
+        )
+
+        if "video" in bokecc_video_playcode and "video" in bokecc_video_infos:
+            # Extract video URL from HTML player:
+            # Bokecc API returns a HTML fragment like "<script src='https://p..."
+            # from which we extract `src` property to build our own player in libcast_xblock
+
+            match = re.search('src="([^"]+)" ', bokecc_video_playcode["video"]["playcode"])
+            if match:
+                video_url = match.group(1)
+                video['js_script_url'] = video_url
+                video['id'] = video_id
+                video['title'] = bokecc_video_infos['video']["title"]
+                video['prev_image'] = bokecc_video_infos['video']["image"]
+                video['thumbnail_url'] = bokecc_video_infos['video']["image"]
+                video['created_at'] = ''
+                video['status'] = "ready"
+                return video
+
+        raise MissingVideo()
+
+    def iter_videos(self):
+        """
+        Iterates through the videos
+        :return: a list of videos
+        """
+
+        playlist_id = BokeccUtil.get_or_create_playlist(self.course_id)
+        # Return all videos in playlist
+        if playlist_id is not None:
+            response = BokeccUtil.bokecc_request_get(
+                'playlist/update',
+                params={'playlistid': playlist_id, }
+            )
+            if "playlist" in response:
+                video_id_list = response["playlist"]["video"]
+                for video in video_id_list:
+                    # Get full info for this video
+                    video_id = video["id"]
+                    if video_id != BokeccUtil.BOKECC_PLAYLIST_FAKE_VIDEO_ID_HACK:
+                        yield self.get_video(video_id)
+
+    def delete_video(self, video_id):
+        """Delete a video
+
+               Returns:
+                   None
+        """
+        response = BokeccUtil.bokecc_request_get(
+            'video/delete',
+            params={'videoid': video_id, }
+        )
+        if "error" in response:
+            raise ClientError("Impossible to delete video")
+
+    def update_video_title(self, video_id, title):
+        """Change a video title"""
+        response = BokeccUtil.bokecc_request_get(
+            'video/update',
+            params={
+                'videoid': video_id,
+                'title': title.encode('utf-8'),
+            }
+        )
+        if "error" in response:
+            raise ClientError("Impossible to change name for video")
+        else:
+            # As per youtube implementation the return value is not used
+            return {}
+
+    ###############################################
+    # To implement later depending on actual needs
+    ###############################################
+
+    def iter_subtitles(self, video_id):
+        pass
+
+    def get_subtitles(self, video_id):
+        # We do not yet manage subtitles
+        pass
+
+    def upload_subtitle(self, video_id, file_object, language):
+        pass
+
+    def delete_video_subtitle(self, video_id, subtitle_id):
+        pass
+
+    def upload_thumbnail(self, video_id, file_object):
+        pass
+
+    def get_upload_url(self, origin=None):
+        """Get a URL for uploading a video.
+            Args:
+                origin (str): current domain name that may be included in CORS headers
+
+            Returns: {
+                "url": "http...", # url on which a POST should be made
+                "file_parameter_name": "path" # name of the file parameter to be sent to the url
+            }
+        """
+        pass
+
+    def create_video(self, payload, title=None):
+        response = BokeccUtil.bokecc_request_get(
+            'video/create',
+            params={'title': title.encode('utf-8'),
+                    'tag': '',
+                    'description': title.encode('utf-8'),
+                    'categoryid': ''
+                    }
+        )
+        if "error" in response:
+            raise ClientError("Error creating videos")
+        return response
+
+
+class BokeccUtil:
+    BOKECC_PLAYER_ID = getattr(settings, 'BOKECC_PLAYER_ID', '30130B6BCFC187A4')
+    BOKECC_URL = getattr(settings, 'BOKECC_URL', 'http://spark.bokecc.com/api/')
+
+    # This is a complete hack: we need to have a video id to create a playlist
+    # So this is an id of a small video that will always be part of any playlist
+    # Warning: if this video is deleted we will not be able to create a playlist
+    BOKECC_PLAYLIST_FAKE_VIDEO_ID_HACK = getattr(settings, 'BOKECC_FAKE_VIDEO_ID', '448AA25E88D95C639C33DC5901307461')
+
+    @staticmethod
+    def get_or_create_playlist( course_id):
+        playlist_id = None
+        try:
+            # Read from BokeCCSettings object
+            course_settings = BokeCCCourseSettings.objects.get(course_id=course_id)
+            playlist_id = course_settings.playlist_id
+        except BokeCCCourseSettings.DoesNotExist:
+            # Then look for it on the Bokecc end point
+            response = BokeccUtil.bokecc_request_get(
+                'playlists',
+                params={}
+            )
+
+            if 'playlists' in response:
+                for playlist in response['playlists']['playlist']:
+                    if playlist["name"] == str(course_id):
+                        playlist_id = playlist["id"]
+                        break
+
+            # We have not found the playlist on the remote server, so we need to create it
+            if playlist_id is None:
+                # create the given playlist
+                response = BokeccUtil.bokecc_request_get(
+                    'playlist/create',
+                    params={'name': str(course_id),
+                            'videoid': BokeccUtil.BOKECC_PLAYLIST_FAKE_VIDEO_ID_HACK,
+                            }
+                )
+                if "playlist" in response:
+                    playlist_id = response["playlist"]["id"]
+            if playlist_id is not None:
+                course_settings, _created = BokeCCCourseSettings.objects.get_or_create(course_id=course_id)
+                course_settings.playlist_id = playlist_id
+                course_settings.save()
+            else:
+                raise ClientError("Impossible to create playlist for course")
+        return playlist_id
+
+    ####################
+    # Utilities
+    ####################
+    @staticmethod
+    def bokecc_request_get(endpoint, params=None):
+
+        if params is None:
+            params = []
+
+        api_key_salt,bokecc_user_id = BokeccUtil.get_auth()
+        full_req_params = params
+        full_req_params['userid'] = bokecc_user_id
+        full_req_params['format'] = 'json'
+
+        url = BokeccUtil.BOKECC_URL + endpoint + '?'
+        complete_url = url + BokeccUtil.__bokecc_get_hqs(full_req_params, api_key_salt)
+        f = urllib.urlopen(complete_url)
+        response = json.loads(f.read())
+
+        if "error" in response:
+            logger.error("Bokecc error: %s", response['error'])
+        return response
+
+    @staticmethod
+    def __bokecc_get_hqs(q, api_key_salt):
+        import hashlib
+        qftime = 'time=%d' % int(time.time())
+        salt = 'salt=%s' % api_key_salt
+        qftail = '&%s&%s' % (qftime, salt)
+        # Build URL and encode parameters
+        l = []
+        for k in q:
+            k = urllib.quote_plus(str(k))
+            v = urllib.quote_plus(str(q[k]))
+            url_param = '%s=%s' % (k, v)
+            l.append(url_param)
+        l.sort()
+        # Build and concatenate URL
+        qs = '&'.join(l)
+        qf = qs + qftail
+        hashqf = 'hash=%s' % (hashlib.new('md5', qf).hexdigest().upper())
+        hqs = '&'.join((qs, qftime, hashqf))
+        return hqs
+
+    @staticmethod
+    def get_auth():
+        api_salt_key = getattr(settings, 'BOKECC_APIKEY', '')
+        user_id = getattr(settings, 'BOKECC_USERID', '')
+        return api_salt_key, user_id
+

--- a/videoproviders/management/commands/videofront-to-bokecc.py
+++ b/videoproviders/management/commands/videofront-to-bokecc.py
@@ -1,0 +1,413 @@
+from django.core.management.base import BaseCommand, CommandError
+from optparse import make_option
+from opaque_keys.edx.keys import CourseKey
+from libcast_xblock import LibcastXBlock
+from requests import ConnectionError
+from xmodule.modulestore.split_mongo import BlockKey
+
+from xmodule.modulestore.exceptions import VersionConflictError
+
+from xmodule.modulestore import ModuleStoreEnum
+
+import xmodule.modulestore.django
+from videoproviders.api import ClientError
+
+from videoproviders.api.videofront import Client as videofrontclient
+from videoproviders.api.bokecc import BokeccUtil
+
+import requests
+import json
+from tempfile import NamedTemporaryFile
+import hashlib
+import time
+
+class Command(BaseCommand):
+    help = """
+       Fetch course videos and upload it to bokecc
+       """
+
+    option_list = BaseCommand.option_list + (
+        make_option('-c', '--courseid',
+                    metavar='COURSEID',
+                    dest='courseid',
+                    default=None,
+                    help='Course to fetch videos from'),
+        make_option('-s', '--chunksize',
+                    metavar='CHUNKSIZE',
+                    dest='chunksize',
+                    default=(1024 * 1024), # 4Mb max is recommended (http://doc.bokecc.com/vod/dev/uploadAPI/upload02/)
+                    help='Chunk size for upload and download'),
+        make_option('-a', '--action',
+                    metavar='COURSEID',
+                    dest='action',
+                    default='upload',
+                    help='Action : upload, playlist, xblock, stats'),
+
+    )
+
+    def handle(self, *args, **options):
+
+        course_key_string = options['courseid']
+        if not course_key_string:
+            raise CommandError("You must specify a course id")
+        action = options['action']
+        if action == 'upload':
+            self.process_upload_videos(course_key_string, options['chunksize'])
+        elif action == "playlist":
+            self.process_playlists(course_key_string)
+        elif action == "xblock":
+            self.process_xblock_video_id(course_key_string)
+        elif action == "stats":
+            self.stats_for_xblock(course_key_string)
+
+
+
+    def stats_for_xblock(self, course_key_string):
+        """
+        Make sure we change the video in the xblock directly so it plays the right bokecc videoid
+        Note: when uploading we made sure that the id was in the video description, we will use that
+        :param course_key_string:
+        :return:
+        """
+        bcc = BokeccVideoHelper()
+        course_id = CourseKey.from_string(course_key_string)
+        store = xmodule.modulestore.django.modulestore()
+        store = store._get_modulestore_for_courselike(course_id)
+        allxblocks = store.get_items(course_id, ModuleStoreEnum.RevisionOption.published_only)
+        print '"Course","VideoID","Path","Bokecc?"'
+        for xblock in store.get_items(course_id, ModuleStoreEnum.RevisionOption.published_only):
+            try:
+                if isinstance(xblock, LibcastXBlock):
+                    video_id = xblock.video_id.encode("utf-8")
+                    ancestry = xblock_ancestry(xblock).encode("utf-8")
+                    print '"{0}","{1}","{2}","{3}"' \
+                        .format(unicode(course_id), video_id, ancestry, "yes" if xblock.is_bokecc_video else "no")
+            except ClientError as e:
+                print 'Error fetching video information({0}) Message:({1})'.format(video_id, e.message)
+
+
+
+    def process_xblock_video_id(self, course_key_string):
+        """
+        Make sure we change the video in the xblock directly so it plays the right bokecc videoid
+        Note: when uploading we made sure that the id was in the video description, we will use that
+        :param course_key_string:
+        :return:
+        """
+        bcc = BokeccVideoHelper()
+        course_id = CourseKey.from_string(course_key_string)
+        store = xmodule.modulestore.django.modulestore()
+        store = store._get_modulestore_for_courselike(course_id)
+        allxblocks = store.get_items(course_id, ModuleStoreEnum.RevisionOption.published_only)
+        newpublishedcoursekey  = None
+        for xblock in allxblocks:
+            try:
+                if isinstance(xblock, LibcastXBlock):
+                    video_id = xblock.video_id.encode("utf-8")
+                    ancestry = xblock_ancestry(xblock).encode("utf-8")
+                    print '{0} -> Checking block ({1}: {2})' \
+                        .format(unicode(course_id), video_id, ancestry)
+                    if xblock.is_bokecc_video:
+                        print '{0} -> Block already on bokecc ({1}: {2}) ' \
+                            .format(unicode(course_id), video_id, ancestry)
+                        continue
+                    bccvideo = bcc.check_video_exists(video_id)
+                    if bccvideo:
+                        print '{0} -> Changing the nature of the xblock ({1}: {2}) to bokecc id:{3} ' \
+                            .format(unicode(course_id), video_id, ancestry, bccvideo['id'])
+                        # Make sure we have the right version of the xblock as in draft versionning
+                        # mode it all changes every time we update a block
+                        block_key = BlockKey.from_usage_key(xblock.location)
+                        ckey = xblock.location.course_key
+                        if newpublishedcoursekey:
+                            ckey = newpublishedcoursekey
+
+                        newxblock = store.get_item(ckey.make_usage_key(block_key.type, block_key.id),{})
+                        newxblock.is_bokecc_video = True
+                        newxblock.video_id = bccvideo['id']
+                        newitem = store.update_item(newxblock, ModuleStoreEnum.UserID.mgmt_command)
+                        if not newpublishedcoursekey or newpublishedcoursekey != newitem.location.course_key:
+                            newpublishedcoursekey = newitem.location.course_key
+            except ClientError as e:
+                print 'Error fetching video information({0}) Message:({1})'.format(video_id, e.message)
+            except VersionConflictError as e:
+                print 'Version Conflict error {0}'.format(e.message)
+
+    def process_playlists(self, course_key_string):
+        """
+        Process the videos from this course, so we make sure that all videos go in the right playlist
+        :param course_key_string:
+        :return:
+        """
+        bcc = BokeccVideoHelper()
+        course_id = CourseKey.from_string(course_key_string)
+        videos = course_video_xblock_generator(course_key_string)
+        videoidlist = []
+        for video in videos:
+            bccvideo = bcc.check_video_exists(video['id'])
+            if bccvideo :
+                videoidlist.append(bccvideo['id'])
+        bcc.set_video_in_playlist(videoidlist, course_id)
+
+    def process_upload_videos(self, course_key_string, chunksize):
+        """
+        Do the video upload for a given course
+        :param course_key_string:
+        :param chunksize:
+        :return:
+        """
+        videos = course_video_xblock_generator(course_key_string)
+        course_id = CourseKey.from_string(course_key_string)
+        for video in videos:
+                hdsource = filter(lambda vs: vs['res'] == 5400, video['video_sources'])
+                if len(hdsource) >= 1:
+                    print 'Video hdsource', hdsource[0]['url']
+                    self.process_video(video['video_sources'][0]['url'], video['title'], video['id'], course_id,
+                                           chunksize)
+
+    def process_video(self,videofronthdurl,videofronttitle,videofrontid,course_id, cs):
+        local_filename = videofronthdurl.split('/')[-1]
+
+        print 'Processing video at {0} with name:{1} and id:{2} '.format(videofronthdurl, videofronttitle, videofrontid)
+
+        bcc = BokeccVideoHelper(cs)
+        # Check first if video exists already on bokeecc
+        existingvideo = bcc.check_video_exists(videofrontid)
+        if existingvideo is not None:
+            print 'Video with videofront Id:{0} is already on Bokecc with ID {1} '.format(videofrontid,existingvideo['id'])
+        else:
+            # If not then download it from videofront
+            r = requests.get(videofronthdurl, stream=True)
+            f = NamedTemporaryFile()
+            chunkcount = 0
+            filesize = r.headers['Content-length']
+            filemd5 = hashlib.md5()
+            for chunk in r.iter_content(chunk_size=cs):
+                if chunk: # filter out keep-alive new chunks
+                    f.write(chunk)
+                    filemd5.update(chunk)
+                    chunkcount += 1
+                    print '(' + str(chunkcount) +'/' + str(int(filesize)/cs+1) + ')',
+
+            # Use title as videofrontid as it is the only field that is searcheable later
+            # Keep the id in description just in case some would rename the files
+            video = bcc.create_video(videofrontid,f.tell(),local_filename, filemd5.hexdigest(),videofrontid)
+            if video:
+                bcc.upload_video(video['videoid'],video['chunkurl'],f,local_filename)
+                # Make sure we change this video an put in in the course playlist
+            f.close()
+
+
+def course_video_xblock_generator(course_key_string):
+    course_id = CourseKey.from_string(course_key_string)
+    store = xmodule.modulestore.django.modulestore()
+    store = store._get_modulestore_for_courselike(course_id)
+
+    videofront_client = videofrontclient(course_key_string)
+
+    for xblock in store.get_items(course_id):
+        try:
+            if isinstance(xblock, LibcastXBlock):
+                video_id = "video_id={}".format(xblock.video_id.encode("utf-8"))
+                provider = "bokecc" if hasattr(xblock,
+                                               'is_bokecc_video') and xblock.is_bokecc_video else "videofront"
+                provider = "youtube" if xblock.is_youtube_video else provider
+                if xblock.video_id :
+                    video = videofront_client.get_video_with_subtitles(xblock.video_id)
+                    yield video
+        except ClientError as e:
+            print 'Error fetching video information({0}) Message:({1})'.format(video_id, e.message)
+
+
+def xblock_ancestry(item):
+    from xmodule.modulestore.exceptions import ItemNotFoundError
+    try:
+        parent = item.get_parent()
+        parent_ancestry = "" if parent is None else xblock_ancestry(parent)
+    except ItemNotFoundError:
+        parent_ancestry = "/ORPHAN"
+    if parent_ancestry:
+        parent_ancestry += u"/"
+    return u"{}{}".format(parent_ancestry, item.display_name)
+
+class BokeccVideoHelper:
+    MAX_RETRY = 10
+
+    def __init__(self, chunksize=1024 * 1024):
+        self.api_salt_key, self.user_id = BokeccUtil.get_auth()
+        self.chunksize = chunksize
+        self.videometa = {}
+
+    def set_video_metadata(self, videoid, filename, filesize, servicetype, md5, metadata_url, chunk_url):
+        videoinfo = {
+            'filename': filename,
+            'filesize': filesize,
+            'servicetype': servicetype,
+            'md5': md5,
+            'metadataurl': metadata_url,
+            'chunkurl': chunk_url
+        }
+        self.videometa[videoid] = videoinfo
+
+    def update_metadata(self, videoid,first=1):
+        if (not self.videometa.has_key(videoid)):
+            return None
+        videoinfo =  self.videometa[videoid]
+        data = {
+            'uid': self.user_id,
+            'ccvid': videoid.encode('ascii'),
+            'first': first,
+            'filename': videoinfo['filename'],
+            'filesize': videoinfo['filesize'],
+            'servicetype': videoinfo['servicetype'],
+            'md5': videoinfo['md5'],
+            'format': 'json'
+        }
+        p = requests.get(videoinfo['metadataurl'], params=data)
+        if p and p.content:
+            result = json.loads(p.content, 'utf-8')
+            if result['result'] == 0:
+                return result
+        return None
+
+    def create_video(self, title, filesize, filename, filemd5, desc):
+        videoid =''
+        bokecc_video = BokeccUtil.bokecc_request_get(
+            'video/create',
+            params={
+                'userid' : self.user_id,
+                'title': title,
+                'filesize' : filesize,
+                'filename' :  filename,
+                'format': 'json',
+                'description': desc
+            }
+        )
+        if not 'error' in bokecc_video:
+            if "uploadinfo" in bokecc_video:
+                # Upload metadata
+                videoid = bokecc_video['uploadinfo']['videoid']
+                metadata_url = bokecc_video['uploadinfo']['metaurl']
+                chunk_url = bokecc_video['uploadinfo']['chunkurl']
+                self.set_video_metadata(videoid,
+                                        filename,
+                                        filesize,
+                                        bokecc_video['uploadinfo']['servicetype'].encode('ascii'),
+                                        filemd5,
+                                        metadata_url,
+                                        chunk_url)
+
+
+                res = self.update_metadata(videoid, 1)
+                if res is not None:
+                        return bokecc_video['uploadinfo']
+
+    def upload_video(self, videoid, uploadchunkurl, videofile,videofilename):
+        fsize = videofile.tell()
+        videofile.seek(0)
+        chunk = videofile.read(self.chunksize)
+        chunkstart = 0
+        currentretry = 0
+        error = ''
+        self.update_metadata(videoid, 2)
+        throttlingtime = 10
+        while chunk:
+            try:
+                data = {
+                       'ccvid': videoid.encode('ascii'),
+                       'format': 'json',
+                }
+                file = { 'file': (videofilename, bytearray(chunk), 'application/octet-stream')}
+                contentrange = "bytes "+ str(chunkstart) + "-" + str(videofile.tell()-1) + "/" + str(fsize)
+                header = {
+                    "Content-Range": contentrange,
+                    'Accept': 'text/*',
+                    'Charset': 'UTF-8',
+                    'Cache-Control': 'no-cache',
+                    'Connection': "Keep-Alive"
+                }
+                print 'Uplodading file {0} to {1} - at {2} '.format(videofilename, uploadchunkurl, chunkstart)
+
+                p = requests.post(uploadchunkurl, files=file, params=data,headers=header)
+                # Check response
+                if p and p.content:
+                    content = json.loads(p.content, 'utf-8')
+                    if 'result' in content and content['result'] == 0:
+                        #No error, so carry on
+                        currentretry = 0
+                        chunkstart = videofile.tell()
+                        chunk = videofile.read(self.chunksize)
+                    else:
+                        currentretry += 1
+                        message = content['msg'].encode('utf-8')
+                        if currentretry > BokeccVideoHelper.MAX_RETRY:
+                            error = 'Issue while uploading file to bokecc ({0}) - at (chunk{1}) - Not retrying '\
+                                .format(message, chunkstart)
+                            break
+                        else :
+                            print 'Issue while uploading file to bokecc ({0}) - retrying (chunk{1}) '\
+                                .format(message, chunkstart)
+                else:
+                    error='General error : no response'
+                    break
+                throttlingtime = 10
+            except ConnectionError as e:
+                print 'Issue while uploading file to bokecc ({0}) - retrying (chunk{1}) '.format(e.message,chunkstart)
+                print 'Throttling for {0} seconds....'.format(throttlingtime)
+                time.sleep(throttlingtime)
+                print 'Restarting ....'
+                throttlingtime += 10
+        if error <> '':
+            print error
+            return False
+        else:
+            return True
+
+    def set_video_in_playlist(self,videoidlist,course_id):
+        playlistid = BokeccUtil.get_or_create_playlist(course_id)
+        response = BokeccUtil.bokecc_request_get(
+            'playlist/update',
+            params={'playlistid': playlistid,
+                    'userid' : self.user_id,
+                    'format': 'json'
+                    }
+        )
+        if not 'error' in response:
+            videos = response['playlist']['video']
+            currentvideoidsset = frozenset([video['id'] for video in videos])
+            uniquevideosidlist = set(videoidlist).union(currentvideoidsset)
+
+            videoliststring = ''
+
+            for videoid in uniquevideosidlist:
+                if not videoliststring == '':
+                    videoliststring += ','
+                videoliststring += videoid
+
+            response = BokeccUtil.bokecc_request_get(
+                'playlist/update',
+                params={'playlistid': playlistid,
+                        'userid': self.user_id,
+                        'videoid': videoliststring,
+                        'format': json
+                       }
+                )
+            if not 'error' in response:
+                print 'Adding video {0} to playlist ({1}):{2} '.format(videoliststring,
+                                                                     response['playlist']['name'],
+                                                                     response['playlist']['id'] )
+            return response
+
+    def check_video_exists(self, videofrontid):
+        response = BokeccUtil.bokecc_request_get(
+            'videos/search',
+            params={'userid': self.user_id,
+                    'q': 'TITLE:'+videofrontid,
+                    'sort': 'CREATION_DATE:DESC',
+                    'format': 'json'
+                    }
+        )
+        if not 'error' in response:
+            if  response['videos']['total'] > 0:
+                return response['videos']['video'][0]
+        return None

--- a/videoproviders/migrations/0007_bokecccoursesettings.py
+++ b/videoproviders/migrations/0007_bokecccoursesettings.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import xmodule_django.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('videoproviders', '0006_explicitely_set_is_youtube_video_xblock_attribute'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='BokeCCCourseSettings',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('course_id', xmodule_django.models.CourseKeyField(max_length=255, db_index=True)),
+                ('playlist_id', models.CharField(max_length=128, verbose_name='Playlist ID')),
+            ],
+            options={
+                'ordering': ('course_id',),
+            },
+        ),
+    ]

--- a/videoproviders/models.py
+++ b/videoproviders/models.py
@@ -81,3 +81,18 @@ class VideofrontCourseSettings(models.Model):
     def __unicode__(self):
         return u"VideofrontCourseSettings: course: %s playlist: %s" % (
                 self.course_id, self.playlist_id)
+
+
+class BokeCCCourseSettings(models.Model):
+    """
+    Store the BokeCC settings for each course. Normally, these fields should
+    be completed automatically by the BokeCC app. Note that in
+    the case of a second course session, you might want to assign to the
+    corresponding course setting the same values as the course setting for the
+    first run.
+    """
+    course_id = CourseKeyField(max_length=255, db_index=True)
+    playlist_id = models.CharField(verbose_name=_("Playlist ID"), max_length=128)
+
+    class Meta:
+        ordering = ('course_id',)


### PR DESCRIPTION
## Purpose

:warning: :warning: :warning: :warning: 

This is a back port of an old branch to add support for the bokecc video provider in one of our white brands.

## Proposal

I've squashed all commits related to this feature. Git commit messages follow:

- Basic get_video functionality for now. Needs to be made more robust and tested as I noticed that the API is non responsive from time to time.
- Extend the video uploader in studio to manage Bokecc videos
- Add more functionalities to the upload dashboard (change title, delete videos, and preview image)
- Remove unused functionalities (video upload + parameters) and code review.
- Fix requirements for bokecc
- Add command line to fetch video and upload them on Bokecc
- Bokecc uploader: Refactor bokecc client so we can share common code between client and command line
- Improve error checking on video uploader command
- Make sure the right header is sent and correct upload
- Refactor the upload_meta function for later use
- Finishing up the loader (playlist + conversion)
- Corrections on playlist + xblock scripts
- Add throttling in case of connection error
- Display all playlist when adding them
- Solve version conflict error
- Fix error when videofront video id is null
- Solve VersionConflictError that is raised because we just updated an xblock so the published course version
- Add stats output
- Fix BokeCC videofront api backend. Closes #4080

BokeCC API used to return video urls in HTTP, our backend was changing protocol HTTPS As BokeCC now use HTTPS, this update simplify url extraction which now works for both protocols