### PR TITLE
Add missing "videoproviders" application migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `videoproviders` missing migration (`0006`)
+
 ## [2.3.0+wb] - 2020-02-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.1+wb] - 2020-02-18
+
 ### Fixed
 
 - Add `videoproviders` missing migration (`0006`)
@@ -33,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `selftest` application
 
-[unreleased]: https://github.com/openfun/fun-apps/compare/v2.3.0+wb...eucalyptus.3-wb
+[unreleased]: https://github.com/openfun/fun-apps/compare/v2.3.1+wb...eucalyptus.3-wb
+[2.3.1+wb]: https://github.com/openfun/fun-apps/compare/v2.3.0+wb...v2.3.1+wb
 [2.3.0+wb]: https://github.com/openfun/fun-apps/compare/v2.2.1+wb...v2.3.0+wb
 [2.2.1+wb]: https://github.com/openfun/fun-apps/compare/v2.2.0+wb...v2.2.1+wb
 [2.2.0+wb]: https://github.com/openfun/fun-apps/releases/tag/v2.2.0+wb

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 2.3.0+wb
+version = 2.3.1+wb
 description = FUN-MOOC White Brands applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)

--- a/videoproviders/migrations/0006_explicitely_set_is_youtube_video_xblock_attribute.py
+++ b/videoproviders/migrations/0006_explicitely_set_is_youtube_video_xblock_attribute.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('videoproviders', '0005_videofrontauth_videofrontcoursesettings'),
+    ]
+
+    operations = [
+    ]


### PR DESCRIPTION
## Purpose

In the previous release (#684), we've backported the bokecc video provider that introduce a new database migration that depends from a missing one.

## Proposal

We've checked out the missing migration from the dogwood branch.