### PR TITLE
🐛(certificates) fix email report recipient bug

### DIFF
--- a/fun/management/commands/course_mode_audit_to_honor.py
+++ b/fun/management/commands/course_mode_audit_to_honor.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
                 subject=subject,
                 body=text_content,
                 from_email=settings.DEFAULT_FROM_EMAIL,
-                to=settings.ADMINS,
+                to=[email for _, email in settings.ADMINS],
             )
         try:
             email.send()


### PR DESCRIPTION
`settings.ADMINS` contant is actually a list of peers like `(name, email)`,
we have to extract email address to pass it to `EmailMultiAlternatives`