### PR TITLE
Automatically add a verified user after payment in a cohort

### DIFF
--- a/payment/templates/payment/email/base.html
+++ b/payment/templates/payment/email/base.html
@@ -76,7 +76,7 @@ from django.utils.translation import ugettext as _
       <td style="text-align:center; padding:6px; font-family:sans-serif; font-size:13px; line-height:1.2; color:#666666;">
 
         <a href="${'https://{lms_base}/{dashboard}/'.format(lms_base=settings.LMS_BASE, dashboard=reverse('dashboard'))}" style="color:#3b73af;text-decoration:none">${_(u"Dashboard")}</a>&nbsp;|&nbsp;
-        <a href="${'https://{lms_base}/{dashboard}/'.format(lms_base=settings.LMS_BASE, dashboard=reverse('contact:contact'))}" style="color:#3b73af;text-decoration:none">${_(u"Help")}</a>&nbsp;|&nbsp;
+        <a href="${'https://{lms_base}/{dashboard}/'.format(lms_base=settings.LMS_BASE, dashboard=reverse('contact'))}" style="color:#3b73af;text-decoration:none">${_(u"Help")}</a>&nbsp;|&nbsp;
         <a href="${'https://{lms_base}/{dashboard}/'.format(lms_base=settings.LMS_BASE, dashboard=reverse('fun-courses:index'))}" style="color:#3b73af;text-decoration:none">${_(u"Courses")}</a><br>
         ${_(u"This is was automatically generated email, please do not reply.")}
         <br><br>

--- a/payment/templates/payment/email/confirmation-email.html
+++ b/payment/templates/payment/email/confirmation-email.html
@@ -35,7 +35,7 @@ ${_(u"Celebrate your achievement through a certificate. This document will help 
 ${_(u"Here is a brief reminder of the mandatory requirements regarding the proctored exam necessary to obtain the certificate:")}
 <ul>
   <li>${_(u"The proctored exam is organized by our provider in a part of the course visible only for students who have selected the certified track")}</li>
-  <li>${_(u"You must verify that your equipment is compatible</li>
+  <li>${_(u"You must verify that your equipment is compatible")}</li>
   <li>${_(u"You must be able to provide an official identity document (passport, identity card ...) at the time of examination")}</li>
   <li>${_(u"You must comply with the rules of the examination explained in the course.")}</li>
 </ul>

--- a/payment/tests/fun_fake_payment.py
+++ b/payment/tests/fun_fake_payment.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""
+Fake payment page for use in acceptance tests.
+This view is enabled in the URLs by the feature flag `ENABLE_PAYMENT_FAKE`.
+
+Note that you will still need to configure this view as the payment
+processor endpoint in order for the shopping cart to use it:
+
+    settings.CC_PROCESSOR['CyberSource']['PURCHASE_ENDPOINT'] = "/payment/fun_payment_fake"
+
+You can configure the payment to indicate success or failure by sending a PUT
+request to the view with param "success"
+set to "success" or "failure".  The view defaults to payment success.
+"""
+import json
+
+import requests
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.generic.base import View
+from edxmako.shortcuts import render_to_response
+from opaque_keys.edx.keys import CourseKey
+from student.models import CourseEnrollment
+from courses.models import Course
+
+
+class PaymentFakeView(View):
+    """
+    Fake payment page for use in acceptance tests.
+    """
+
+    # We store the payment status to respond with in a class
+    # variable.  In a multi-process Django app, this wouldn't work,
+    # since processes don't share memory.  Since Lettuce
+    # runs one Django server process, this works for acceptance testing.
+    PAYMENT_STATUS_RESPONSE = "success"
+
+    @csrf_exempt
+    def dispatch(self, *args, **kwargs):
+        """
+        Disable CSRF for these methods.
+        """
+        return super(PaymentFakeView, self).dispatch(*args, **kwargs)
+
+    def post(self, request):
+        """
+        Render a fake payment page.
+
+        This is an HTML form that:
+
+        * Triggers a POST to `postpay_callback()` on submit.
+
+        * Has hidden fields for all the data CyberSource sends to the callback.
+            - Most of this data is duplicated from the request POST params (e.g. `amount`)
+            - Other params contain fake data (always the same user name and address.
+            - Still other params are calculated (signatures)
+
+        * Serves an error page (HTML) with a 200 status code
+          if the signatures are invalid.  This is what CyberSource does.
+
+        Since all the POST requests are triggered by HTML forms, this is
+        equivalent to the CyberSource payment page, even though it's
+        served by the shopping cart app.
+        """
+        # Here we trigger the notification to the payment API (we skipp the ECOMMERCE PART)
+        course_key = request.POST.get('merchant_defined_data1')
+        order_fake = settings.FUN_PAYMENT_FAKE_ORDER(course_key)
+
+        self.mock_ecommerce_callbacks(request, course_key, order_fake)
+
+        return render_to_response('payment/success.html', {
+            'order': order_fake,
+            'ordered_course':  course_key,
+        })
+
+    def mock_ecommerce_callbacks(self, request, course_key, order_fake):
+        s = requests.Session()
+        # First we trigger the notification to the payment API
+        data = {'username': request.user.username,
+                'email': request.user.email,
+                'order_number': order_fake.get('number'),
+                'fun_test_course_key': course_key
+                # Additional key so to retrieve the course ID.
+                }
+
+        path = reverse('fun-payment-api:payment-notification')
+        post_url = '{}://{}:{}{}'.format(
+            request.environ.get('wsgi.url_scheme'),
+            'localhost',
+            request.environ.get('SERVER_PORT'),
+            path)
+
+        headers = {
+            'X-CSRFToken': request.COOKIES.get('csrftoken')
+        }
+        s.post(post_url, json=data, cookies=request.COOKIES, headers=headers)
+
+        # Secondly we trigger the course enrollment in verified mode
+        # This should normally done via a callback from ecommerce to edX
+        # through 'commerce_api:v1:courses:retrieve_update' or the v0 equivalent
+        edx_course_key = CourseKey.from_string(course_key)
+        enrollment = CourseEnrollment.get_enrollment(request.user,
+                                                     course_key=edx_course_key)
+        if enrollment:
+            enrollment.update_enrollment(is_active=True, mode='verified')
+            enrollment.save()

--- a/payment/urls.py
+++ b/payment/urls.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from django.conf.urls import url, patterns
+from django.conf import settings
 
 # this url file is namespaced 'payment'
 
@@ -15,3 +16,10 @@ urlpatterns = patterns('payment.views',
     url(r'^terms/get/$', 'get_payment_terms', name="get-terms"),
     url(r'^terms/accept/$', 'accept_payment_terms', name="accept-terms"),
 )
+
+if settings.FEATURES.get('ENABLE_PAYMENT_FAKE'):
+    from tests.fun_fake_payment import PaymentFakeView
+    urlpatterns += patterns(
+        'payment.tests.fun_fake_payment',
+        url(r'^fun_payment_fake', PaymentFakeView.as_view()),
+    )

--- a/payment_api/views.py
+++ b/payment_api/views.py
@@ -2,7 +2,10 @@
 
 import logging
 
+from django.conf import settings
 from django.contrib.auth.models import User
+from django.db import transaction
+from django.utils.decorators import method_decorator
 
 from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
@@ -12,7 +15,8 @@ from rest_framework_oauth.authentication import OAuth2Authentication
 
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 
-from payment.utils import send_confirmation_email
+from payment.utils import send_confirmation_email, \
+    register_user_verified_cohort, get_order, get_course
 
 from .serializers import PaymentNotificationSerializer
 
@@ -26,6 +30,10 @@ class PaymentNotificationAPIView(APIView):
     """
     authentication_classes = (OAuth2Authentication, SessionAuthentication)
 
+    @method_decorator(transaction.non_atomic_requests) # Used to add user into cohort
+    def dispatch(self, *args, **kwargs):    # pylint: disable=missing-docstring
+        return super(PaymentNotificationAPIView, self).dispatch(*args, **kwargs)
+
     def post(self, request, format=None):
         serializer = PaymentNotificationSerializer(data=request.data)
         if serializer.is_valid():
@@ -38,7 +46,15 @@ class PaymentNotificationAPIView(APIView):
                     status='approved',
                     reviewing_service='Automatic Paybox',
                 )
-            send_confirmation_email(user, request.data['order_number'])
+            order = None
+            if settings.FEATURES.get('ENABLE_PAYMENT_FAKE'):
+                order = settings.FUN_PAYMENT_FAKE_ORDER(request.data['fun_test_course_key'])
+                # Don't send confirmation email when testing
+            else:
+                order = get_order(user, request.data['order_number'])
+                send_confirmation_email(user, order)
+
+            register_user_verified_cohort(user,  order)
             logger.info('Created SoftwareSecurePhotoVerification object and sent FUN confirmation email to user %s',
                     user.username)
             return Response()


### PR DESCRIPTION
When user completes payment make sure that he/she is added to a cohort named DEFAULT_VERIFIED_COHORT_NAME ("certificat"). 
The user will be added to all matching cohorts in the course he/she is paying for. 

**Background information **

The addition is made when edX is called back after the payment (so here from paybox). In this case we used to send a confirmation email and now we also add the user to matching cohorts. 
The name of the cohort to look for is "certificat" but can be changed in the django settings (the name of the variable is DEFAULT_VERIFIED_COHORT_NAME)
However, if for some reason the routines stops before the callback, the user will never be added to the cohort and will need to be via the UI.
edX has since resolved this issue by creating cohorts that will automatically get users that are on a specific enrolment track (verified for example). So this is a temporary solution until we get to an upgraded version of the edX platform.

**Other changes**

- There is now a mock for the payment/ecommerce entity, so we can just fake the payment step and be registered as verified user in the course
- Some templates (email) needed attention (contact:contact page did not exist anymore and there was a closing brace missing in one of them).
