### PR TITLE
🐛(thumbnails) catch OS errors on thumbnail generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Catch OS errors on thumbnail generation
+
 ## [5.4.1] - 2020-07-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.2] - 2020-10-01
+
 ### Fixed
 
 - Catch OS errors on thumbnail generation
@@ -51,7 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rewrite constants related to fun's PDF certificates urls
 
-[unreleased]: https://github.com/openfun/fun-apps/compare/v5.4.1...HEAD
+[unreleased]: https://github.com/openfun/fun-apps/compare/v5.4.2...HEAD
+[5.4.2]: https://github.com/openfun/fun-apps/compare/v5.4.0...v5.4.2
 [5.4.1]: https://github.com/openfun/fun-apps/compare/v5.4.0...v5.4.1
 [5.4.0]: https://github.com/openfun/fun-apps/compare/v5.3.1...v5.4.0
 [5.3.1]: https://github.com/openfun/fun-apps/compare/v5.3.0...v5.3.1

--- a/courses/management/commands/update_courses.py
+++ b/courses/management/commands/update_courses.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import logging
 import optparse
 import StringIO
 
@@ -22,6 +23,8 @@ from xmodule.modulestore.django import modulestore
 from courses import settings as courses_settings
 from courses.models import Course, CourseUniversityRelation
 from universities.models import University
+
+logger = logging.getLogger(__name__)
 
 
 class CourseHandler(object):
@@ -76,7 +79,8 @@ class CourseHandler(object):
                 self.memory_image_file,
                 relative_name='courses-thumbnails/{}'.format(base_filename)
             ).get_thumbnail(options)
-        except InvalidImageFormatError:
+        except (InvalidImageFormatError, OSError) as err:
+            logger.error(err)
             thumbnail = None
         return thumbnail
 

--- a/newsfeed/models.py
+++ b/newsfeed/models.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import ckeditor.fields
+import logging
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -12,6 +13,8 @@ from django.utils.translation import get_language
 
 from easy_thumbnails.exceptions import InvalidImageFormatError
 from easy_thumbnails.files import get_thumbnailer
+
+logger = logging.getLogger(__name__)
 
 
 class ArticleManager(models.Manager):
@@ -138,7 +141,8 @@ class Article(models.Model):
             }
             thumbnail_options = {'crop': 'smart', 'size': sizes[size], 'upscale': True}
             return thumbnailer.get_thumbnail(thumbnail_options)
-        except InvalidImageFormatError:
+        except (InvalidImageFormatError, OSError) as err:
+            logger.error(err)
             return ''  ## todo: generic image
 
     def get_absolute_url(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 5.4.1
+version = 5.4.2
 description = FUN MOOC applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)

--- a/universities/models.py
+++ b/universities/models.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
@@ -10,6 +11,8 @@ from ckeditor.fields import RichTextField
 
 from .managers import UniversityQuerySet
 from . import choices as universities_choices
+
+logger = logging.getLogger(__name__)
 
 
 class University(models.Model):
@@ -64,7 +67,8 @@ class University(models.Model):
         try:
             thumbnail = get_thumbnailer(self.banner).get_thumbnail(options)
             return thumbnail.url
-        except InvalidImageFormatError:
+        except (InvalidImageFormatError, OSError) as err:
+            logger.error(err)
             return ''  # we could return a nice grey image
 
     def get_short_name(self):
@@ -75,5 +79,6 @@ class University(models.Model):
         try:
             thumbnail = get_thumbnailer(self.logo).get_thumbnail(options)
             return thumbnail.url
-        except InvalidImageFormatError:
+        except (InvalidImageFormatError, OSError) as err:
+            logger.error(err)
             return ''  # we could return a nice grey image


### PR DESCRIPTION
## Purpose

If the filesystem becomes available, we would like to avoid crashing with a 500 error. A site without images is reasonably better than a 500.

## Proposal

Add OSError catching around calls to generate thumbnails.