### PR TITLE
Use cdn for thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow placing thumbnails related media files behind a CDN
+
 ## [5.4.2] - 2020-10-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.0] - 2020-10-02
+
 ### Added
 
 - Allow placing thumbnails related media files behind a CDN
@@ -57,7 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rewrite constants related to fun's PDF certificates urls
 
-[unreleased]: https://github.com/openfun/fun-apps/compare/v5.4.2...HEAD
+[unreleased]: https://github.com/openfun/fun-apps/compare/v5.5.0...HEAD
+[5.5.0]: https://github.com/openfun/fun-apps/compare/v5.4.2...v5.5.0
 [5.4.2]: https://github.com/openfun/fun-apps/compare/v5.4.0...v5.4.2
 [5.4.1]: https://github.com/openfun/fun-apps/compare/v5.4.0...v5.4.1
 [5.4.0]: https://github.com/openfun/fun-apps/compare/v5.3.1...v5.4.0

--- a/course_pages/templates/course_pages/course-block/big.html
+++ b/course_pages/templates/course_pages/course-block/big.html
@@ -1,5 +1,6 @@
 ## mako
 <%!
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils.translation import pgettext, ugettext as _
 from util.date_utils import strftime_localized
@@ -19,7 +20,7 @@ from util.date_utils import strftime_localized
 			% else:
 				<div class="type transparent"></div>
 			% endif
-				<img class="img-responsive" src="${ course.get_thumbnail_url('big') }">
+				<img class="img-responsive" src="${ getattr(settings, 'CDN_BASE_URL', None) or '' }${ course.get_thumbnail_url('big') }">
 		</div>
 		<div class="middle">
 			<div class="title">

--- a/course_pages/templates/course_pages/course-block/small.html
+++ b/course_pages/templates/course_pages/course-block/small.html
@@ -1,5 +1,6 @@
 ## mako
 <%!
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 %>
@@ -18,7 +19,7 @@ from django.utils.translation import ugettext as _
             % else:
                 <div class="type transparent"></div>
             % endif
-                <img class="img-responsive" src="${ course.get_thumbnail_url('small') }">
+                <img class="img-responsive" src="${ getattr(settings, 'CDN_BASE_URL', None) or '' }${ course.get_thumbnail_url('small') }">
         </div>
         <div class="middle">
             <div class="title">

--- a/course_pages/templates/course_pages/feed/feed.html
+++ b/course_pages/templates/course_pages/feed/feed.html
@@ -1,12 +1,15 @@
 ## mako
 <%!
+from django.conf import settings
 from django.utils.translation import ugettext as _
+
+media_site = getattr(settings, 'CDN_BASE_URL', None) or site
 %>
 <html>
 <body>
 <p>
     <center>
-        <img src="${protocol}${site}${course.get_thumbnail_url('big')}">
+        <img src="${protocol}${media_site}${course.get_thumbnail_url('big')}">
         <h1><a href="${protocol}${site}${course.get_absolute_url()}">${course.title}</a></h1>
     </center>
 </p>

--- a/course_pages/views.py
+++ b/course_pages/views.py
@@ -87,13 +87,14 @@ class CoursesFeed(Feed):
         Add the 'content' field of the 'Entry' item, to be used by the custom feed generator.
         """
         protocol, site = self.get_site()
+        media_site = getattr(settings, 'CDN_BASE_URL', None) or site
         return {
             'university': course.university_name,
             'language': course.get_language_display(),
             'level': course.get_level_display(),
             'short_description': course.short_description,
             'subjects': ', '.join([s.name for s in course.subjects.all()]),
-            'thumbnail_url': protocol + site + course.get_thumbnail_url('big'),
+            'thumbnail_url': protocol + media_site + course.get_thumbnail_url('big'),
             'start_date': course.start_date.isoformat() if course.start_date else '',
             'end_date': course.end_date.isoformat() if course.end_date else '',
             'enrollment_start_date': course.enrollment_start_date.isoformat() if course.enrollment_start_date else '',

--- a/funsite/templates/lms/courseware/course_about.html
+++ b/funsite/templates/lms/courseware/course_about.html
@@ -105,13 +105,14 @@ from funsite.utils import is_paid_course
 <%block name="meta_extra">
     <%
     fun_course = get_fun_course(course)
+    media_site = getattr(settings, 'CDN_BASE_URL', None) or "//www.fun-mooc.fr"
     %>
     <meta property="og:site_name" content="FUN-MOOC"/>
     <meta property="og:url" content="//www.fun-mooc.fr${reverse('about_course', args=[fun_course.key])}" />
     <meta property="og:title" content="${course.display_name_with_default}" />
     <meta property="og:description" content="${get_course_about_section(request, course, 'short_description')}" />
     <meta property="og:locale" content="fr_FR" />
-    <meta property="og:image" content="//www.fun-mooc.fr${ fun_course.get_thumbnail_url('facebook') }" />
+    <meta property="og:image" content="${media_site}${ fun_course.get_thumbnail_url('facebook') }" />
 
 </%block>
 
@@ -185,7 +186,7 @@ from funsite.utils import is_paid_course
                     % if get_course_about_section(request, course, "video"):
                     <div class="video-button"></div>
                     % endif
-                    <img src="${ fun_course.get_thumbnail_url('about') }" class="img-responsive">
+                    <img src="${ getattr(settings, 'CDN_BASE_URL', None) or '' }${ fun_course.get_thumbnail_url('about') }" class="img-responsive">
                 </div>
 
                 <div class="course-about-university-logo">
@@ -193,10 +194,10 @@ from funsite.utils import is_paid_course
                     % if first_university:
                         % if first_university.detail_page_enabled:
                             <a href="${first_university.get_absolute_url()}">
-                                <img src="${first_university.get_logo_thumbnail()}">
+                                <img src="${ getattr(settings, 'CDN_BASE_URL', None) or ''}${first_university.get_logo_thumbnail()}">
                             </a>
                         % else:
-                            <img src="${first_university.get_logo_thumbnail()}">
+                            <img src="${ getattr(settings, 'CDN_BASE_URL', None) or ''}${first_university.get_logo_thumbnail()}">
                         % endif
                     % endif
                 </div>
@@ -208,7 +209,7 @@ from funsite.utils import is_paid_course
                     % if get_course_about_section(request, course, "video"):
                     <div class="video-button"></div>
                     % endif
-                    <img src="${ fun_course.get_thumbnail_url('about') }">
+                    <img src="${ getattr(settings, 'CDN_BASE_URL', None) or ''}${ fun_course.get_thumbnail_url('about') }">
                 </div>
 
                 %if user.is_authenticated() and registered:
@@ -417,7 +418,7 @@ from funsite.utils import is_paid_course
                     % if get_course_about_section(request, course, "video"):
                     <div class="video-button"></div>
                     % endif
-                    <img src="${ fun_course.get_thumbnail_url('about') }" class="img-responsive">
+                    <img src="${ getattr(settings, 'CDN_BASE_URL', None) or ''}${ fun_course.get_thumbnail_url('about') }" class="img-responsive">
                 </div>
 
 

--- a/payment/templates/payment/order.html
+++ b/payment/templates/payment/order.html
@@ -1,5 +1,6 @@
 ## mako
 <%!
+    from django.conf import settings
     from django.utils.translation import ugettext as _
 %>
 
@@ -70,7 +71,7 @@
                     </p>
                 </div>
                 <div class="col-sm-13 image">
-                    <img class="img-responsive center-block image-course" src="${ordered_course.get_thumbnail_url('small')}"
+                    <img class="img-responsive center-block image-course" src="${ getattr(settings, 'CDN_BASE_URL', None) or ''}${ordered_course.get_thumbnail_url('small')}"
                          alt="${ordered_course.title} Image"/>
                 </div>
             </div>

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 5.4.2
+version = 5.5.0
 description = FUN MOOC applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION
### Purpose

Thumbnails are heavily queried and should be placed behind the CDN.

### Proposal

Modify all thumbnail image src attributes to use the CDN domain when set.

