### PR TITLE
Fix update courses fail on invalid key error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.1] - 2020-10-22
+
 ### Fixed
 
 - Log error but continue course updates when encountering invalid key error
@@ -63,7 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rewrite constants related to fun's PDF certificates urls
 
-[unreleased]: https://github.com/openfun/fun-apps/compare/v5.5.0...HEAD
+[unreleased]: https://github.com/openfun/fun-apps/compare/v5.5.1...HEAD
+[5.5.1]: https://github.com/openfun/fun-apps/compare/v5.5.0...v5.5.1
 [5.5.0]: https://github.com/openfun/fun-apps/compare/v5.4.2...v5.5.0
 [5.4.2]: https://github.com/openfun/fun-apps/compare/v5.4.0...v5.4.2
 [5.4.1]: https://github.com/openfun/fun-apps/compare/v5.4.0...v5.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Log error but continue course updates when encountering invalid key error
+
 ## [5.5.0] - 2020-10-02
 
 ### Added

--- a/courses/management/commands/update_courses.py
+++ b/courses/management/commands/update_courses.py
@@ -132,10 +132,15 @@ class Command(BaseCommand):
         course in SQL Course table.
         '''
         for mongo_course in mongo_courses:
-            self.update_course(
-                mongo_course=mongo_course,
-                assign_universities=assign_universities
-            )
+            try:
+                self.update_course(
+                    mongo_course=mongo_course,
+                    assign_universities=assign_universities
+                )
+            except InvalidKeyError as err:
+                # Log the error but continue indexing other courses
+                logger.error(err)
+
         self.stdout.write('Number of courses parsed: {}\n'.format(len(mongo_courses)))
         return None
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 5.5.0
+version = 5.5.1
 description = FUN MOOC applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION
## Purpose

It can happen that a course has an invalid key but it should not break the update_courses command for other courses. 

## Proposal

I propose to catch InvalidKeyError, log an error to Sentry and continue with the remaining courses.
