### PR TITLE
Migration to richie 2.0.0 beta.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add a `richie` view to redirect user on richie after login/registration
+### Added
+
+- Add a `next` query param on legal acceptance view to redirect user after acceptance to the route
+  provided in this param.
+
+- Add a `richie` view to redirect user to richie after login/registration
 
 ## [5.5.1] - 2020-10-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add a `richie` view to redirect user on richie after login/registration
+
 ## [5.5.1] - 2020-10-22
 
 ### Fixed

--- a/fun/lms/urls.py
+++ b/fun/lms/urls.py
@@ -5,6 +5,7 @@ from django.conf.urls import url, include, patterns
 from django.conf.urls.static import static
 from django.core.urlresolvers import reverse_lazy
 from django.views.generic import RedirectView
+from . import views
 
 import openassessment.fileupload.urls
 
@@ -70,6 +71,9 @@ urlpatterns = patterns('',
 
     # Ora2 file upload
     url(r'^openassessment/storage', include(openassessment.fileupload.urls)),
+
+    # Richie Redirect
+    url(r'^richie/(?P<redirect_to>.*)$', views.richie, name="richie_gateway"),
 )
 
 # Ckeditor - Used by Univerity app

--- a/fun/lms/views.py
+++ b/fun/lms/views.py
@@ -1,0 +1,16 @@
+import re
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.http import HttpResponse
+from django.shortcuts import redirect
+
+
+def richie(request, redirect_to):
+    """Extract params from route to redirect to the right Richie view"""
+    if (getattr(settings, "PLATFORM_RICHIE_URL", None) is not None):
+        return redirect("{richie_url:s}/{target:s}".format(
+            richie_url=settings.PLATFORM_RICHIE_URL,
+            target=redirect_to
+        ))
+
+    return redirect(reverse("dashboard"))

--- a/fun/lms/views.py
+++ b/fun/lms/views.py
@@ -7,10 +7,11 @@ from django.shortcuts import redirect
 
 def richie(request, redirect_to):
     """Extract params from route to redirect to the right Richie view"""
-    if (getattr(settings, "PLATFORM_RICHIE_URL", None) is not None):
-        return redirect("{richie_url:s}/{target:s}".format(
-            richie_url=settings.PLATFORM_RICHIE_URL,
-            target=redirect_to
-        ))
+    if getattr(settings, "PLATFORM_RICHIE_URL", None) is not None:
+        return redirect(
+            "{richie_url:s}/{target:s}".format(
+                richie_url=settings.PLATFORM_RICHIE_URL, target=redirect_to
+            )
+        )
 
     return redirect(reverse("dashboard"))

--- a/fun/middleware/enforce_legal_acceptance.py
+++ b/fun/middleware/enforce_legal_acceptance.py
@@ -21,7 +21,7 @@ AGREEMENT_WHITELIST = map(
         r'.*search.*',
         r'.*revision.*',
         r'^/static/.*',
-        r'^/api/user/.*',
+        r'^/api/.*',
         r'^/c4x.*',
         r'.*logout.*$',
         r'.*asset.*',
@@ -40,7 +40,11 @@ def ensure_terms_accepted(func):
     """
     def wrapped(request, *args, **kwargs):
         if not legal_acceptance(request.user):
-            return redirect(TERMS_AND_CONDITIONS_AGREEMENT, *args, **kwargs)
+            redirect_to = '{path:s}?next={next:s}'.format(
+                path=TERMS_AND_CONDITIONS_AGREEMENT,
+                next=request.path
+            )
+            return redirect(redirect_to, *args, **kwargs)
         else:
             return func(request, *args, **kwargs)
     return wrapped

--- a/payment/templates/payment/terms-and-conditions.html
+++ b/payment/templates/payment/terms-and-conditions.html
@@ -31,7 +31,7 @@ from django.utils.translation import ugettext as _
               </div>
 
               <div class="display-fun-payment-terms-footer">
-                <form action="${reverse('payment:accept-terms')}" method="POST">
+                <form action="${reverse('payment:accept-terms')}?next=${next | u}" method="POST">
                     <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}">
                     <button type="submit" id="validate-terms" class="btn-terms">${_("Accept")}</button>
                 </form>

--- a/payment/tests/test_terms.py
+++ b/payment/tests/test_terms.py
@@ -19,19 +19,22 @@ class TermsAndConditionTest(TestCase):
         Create 2 kinds of terms and condition, one in 2 versions
         """
         self.user = UserFactory()
-        self.terms1v10 = TermsAndConditionsFactory(name='test1', version='1.0',
-                text=u"https://xkcd.com/501/")
-        self.terms1v11 = TermsAndConditionsFactory(name='test1', version='1.1',
-                text=self.terms1v10.text)
-        self.terms2v10 = TermsAndConditionsFactory(name='test2', version='1.0',
-                text=self.terms1v10.text)
+        self.terms1v10 = TermsAndConditionsFactory(
+            name="test1", version="1.0", text=u"https://xkcd.com/501/"
+        )
+        self.terms1v11 = TermsAndConditionsFactory(
+            name="test1", version="1.1", text=self.terms1v10.text
+        )
+        self.terms2v10 = TermsAndConditionsFactory(
+            name="test2", version="1.0", text=self.terms1v10.text
+        )
 
     def test_get_latest(self):
         """
         Latest version of `test1` should be 1.1
         """
-        terms = TermsAndConditions.get_latest(name='test1')
-        self.assertEqual('1.1', terms.version)
+        terms = TermsAndConditions.get_latest(name="test1")
+        self.assertEqual("1.1", terms.version)
 
     def test_user_never_accepted(self):
         """
@@ -39,17 +42,20 @@ class TermsAndConditionTest(TestCase):
         """
         # User should have to accept the newer one of `test1`
         terms = TermsAndConditions.user_has_to_accept_new_version(
-                name='test1', user=self.user)
+            name="test1", user=self.user
+        )
         self.assertEqual(self.terms1v11, terms)
 
         # User should have to accept the only one of `test2`
         terms = TermsAndConditions.user_has_to_accept_new_version(
-                name='test2', user=self.user)
+            name="test2", user=self.user
+        )
         self.assertEqual(self.terms2v10, terms)
 
         # User do not have to accept a non existent terms
         terms = TermsAndConditions.user_has_to_accept_new_version(
-                name='non-existent', user=self.user)
+            name="non-existent", user=self.user
+        )
         self.assertEqual(False, terms)
 
     def test_user_accept_terms(self):
@@ -58,7 +64,8 @@ class TermsAndConditionTest(TestCase):
         """
         # User has to accept latest of `test1`
         terms = TermsAndConditions.user_has_to_accept_new_version(
-                name='test1', user=self.user)
+            name="test1", user=self.user
+        )
         # OK then
         result = terms.accept(user=self.user)
         self.assertEqual(True, result)
@@ -68,7 +75,8 @@ class TermsAndConditionTest(TestCase):
 
         # what version of `test1`does user have to accept ?
         terms = TermsAndConditions.user_has_to_accept_new_version(
-                name='test1', user=self.user)
+            name="test1", user=self.user
+        )
         self.assertEqual(False, result)  # already accepted latest
 
     def test_user_has_already_acccepted(self):
@@ -77,17 +85,20 @@ class TermsAndConditionTest(TestCase):
         """
         UserAcceptance.objects.create(user=self.user, terms=self.terms1v11)
         terms = TermsAndConditions.user_has_to_accept_new_version(
-                name='test1', user=self.user)
+            name="test1", user=self.user
+        )
         self.assertEqual(False, terms)
 
     def test_version_zero(self):
         """
         If a terms has a version 0 we want to considere it as automaticaly accepted.
         """
-        TermsAndConditions.objects.create(name='test3', version='0',
-                text=u"https://xkcd.com/501/")
+        TermsAndConditions.objects.create(
+            name="test3", version="0", text=u"https://xkcd.com/501/"
+        )
         terms = TermsAndConditions.user_has_to_accept_new_version(
-                name='test3', user=self.user)
+            name="test3", user=self.user
+        )
         self.assertEqual(False, terms)
 
 
@@ -95,17 +106,19 @@ class TermsAndConditionViewsTest(TestCase):
     """
     Create FUN terms and condition, and validate user forced acceptance
     """
+
     def setUp(self):
         self.user = UserFactory()
-        self.terms1v10 = TermsAndConditionsFactory(name=PAYMENT_TERMS, version='1.0',
-                text=u"https://xkcd.com/501/")
+        self.terms1v10 = TermsAndConditionsFactory(
+            name=PAYMENT_TERMS, version="1.0", text=u"https://xkcd.com/501/"
+        )
 
     @skipUnlessLms
     def test_forced_acceptation(self):
         """
         User should be redirected to terms page until he accepted
         """
-        self.client.login(username=self.user.username, password='test')
+        self.client.login(username=self.user.username, password="test")
         # attempt to acces dashboard when still having to accept terms
         response = self.client.get(reverse("dashboard"))
         # should be redirected to acceptance page
@@ -114,3 +127,23 @@ class TermsAndConditionViewsTest(TestCase):
         response = self.client.post(reverse("payment:accept-terms"))
         # and should be redirected to dashbord
         self.assertRedirects(response, reverse("dashboard"))
+
+    @skipUnlessLms
+    def test_forced_acceptation_with_next_param(self):
+        """
+        Once user accepted new terms and conditions, he/she should be redirected
+        to the route provided in next param if it exists
+        """
+        self.client.login(username=self.user.username, password="test")
+        # attempt to acces dashboard when still having to accept terms
+        response = self.client.get(
+            "/u/{username:s}".format(username=self.user.username)
+        )
+        # should be redirected to acceptance page
+        self.assertRedirects(response, reverse("payment:terms-page"))
+        # accept then
+        response = self.client.post(reverse("payment:accept-terms"))
+        # and should be redirected to dashbord
+        self.assertRedirects(
+            response, reverse("/u/{username:s}".format(username=self.user.username))
+        )

--- a/payment/views.py
+++ b/payment/views.py
@@ -68,7 +68,8 @@ def paybox_success(request):
 
     if settings.FUN_ECOMMERCE_DEBUG_NO_NOTIFICATION:
         # TODO what should we do with the response?
-        _response = requests.post(settings.ECOMMERCE_NOTIFICATION_URL, request.GET)
+        _response = requests.post(
+            settings.ECOMMERCE_NOTIFICATION_URL, request.GET)
 
     order = get_order_or_404(request.user, request.GET['reference-fun'])
     course = get_course_or_404(order)
@@ -151,13 +152,14 @@ def payment_terms_page(request, force):
             TermsAndConditions.user_has_to_accept_new_version(
                 PAYMENT_TERMS,
                 request.user)
-            )
+    )
     terms = TermsAndConditions.get_latest(name=PAYMENT_TERMS)
 
     return render_to_response('payment/terms-and-conditions.html', {
-            'terms': terms,
-            'force': force,
-            })
+        'force': force,
+        'next': request.GET.get('next', reverse('dashboard')),
+        'terms': terms,
+    })
 
 
 @require_GET
@@ -198,10 +200,12 @@ def accept_payment_terms(request):
     )
     terms.accept(request.user)
     data['accepted'] = terms.version
-
+    try:
+        redirect_to = request.GET['next']
+    except KeyError:
+        redirect_to = reverse('dashboard')
 
     if request.is_ajax():
         return HttpResponse(json.dumps(data), content_type="application/json")
     else:
-        return redirect(reverse('dashboard'))
-
+        return redirect(redirect_to)


### PR DESCRIPTION
## Purpose

Since the release of `richie 2.0.0-beta.20`, after login/registration, EDX should redirect user on Richie. In the case of FUN Mooc, just before redirect, a middleware is in charge to check that user has accepted latest version of terms and conditions.
We have to maintain this logic with the new richie version.

## Proposal

- [x] Whitelist api routes used by Richie from legal_acceptance middleware
- [x] Create a richie view to redirect user on richie after login/registration
- [x] Use a next query param on legal_acceptance to redirect user on the page he comes