### PR TITLE
✨(courses) allow synchronizing course runs via synchronization hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.0] - 2021-01-06
+
 ### Added
 
 - Allow synchronizing course runs via an external synchronization hook
@@ -81,7 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rewrite constants related to fun's PDF certificates urls
 
-[unreleased]: https://github.com/openfun/fun-apps/compare/v5.6.0...HEAD
+[unreleased]: https://github.com/openfun/fun-apps/compare/v5.7.0...HEAD
+[5.7.0]: https://github.com/openfun/fun-apps/compare/v5.6.0...v5.7.0
 [5.6.0]: https://github.com/openfun/fun-apps/compare/v5.5.1...v5.6.0
 [5.5.1]: https://github.com/openfun/fun-apps/compare/v5.5.0...v5.5.1
 [5.5.0]: https://github.com/openfun/fun-apps/compare/v5.4.2...v5.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow synchronizing course runs via an external synchronization hook
+
 ### Fixed
 
 - Fix "update_courses" command used in cron job for mass updates

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -1,15 +1,69 @@
 # -*- coding: utf-8 -*-
+import hashlib
+import hmac
+import json
+import logging
+
+from django.conf import settings
+from django.core.management import call_command
 
 from celery import shared_task
+from microsite_configuration import microsite
+from opaque_keys.edx.keys import CourseKey
+import requests
+from xmodule.modulestore.django import modulestore
 
-from django.core.management import call_command
+logger = logging.getLogger(__name__)
 
 
 @shared_task
 def update_courses_meta_data(*args, **kwargs):
     """
-    A task that serves as proxy to the management command.
-    Can be used for instance when a signal is fired to update
-    a single course or to run periodic tasks.
+    A task to call when a course is updated in OpenEdX.
+    It calls:
+    - the "update_courses" management command to update the "fun-apps" search index.
+    - each course run hook url defined in the `COURSE_HOOKS` setting with scheduling information
     """
-    call_command('update_courses', *args, **kwargs)
+    # Update fun-apps course catalog
+    call_command("update_courses", *args, **kwargs)
+
+    hooks = getattr(settings, "COURSE_HOOKS", [])
+    if not hooks:
+        return
+
+    # Synchronize with external course hook
+    course_id = kwargs["course_id"]
+    course_key = CourseKey.from_string(course_id)
+    course = modulestore().get_course(course_key)
+    edxapp_domain = microsite.get_value("site_domain", settings.SITE_NAME)
+    data = {
+        "resource_link": "https://{:s}/courses/{:s}/info/".format(
+            edxapp_domain, course_id
+        ),
+        "start": course.start.isoformat(),
+        "end": course.end.isoformat(),
+        "enrollment_start": course.enrollment_start.isoformat(),
+        "enrollment_end": course.enrollment_end.isoformat(),
+        "languages": ["fr"],
+    }
+    json_data = json.dumps(data)
+
+    for hook in hooks:
+        signature = hmac.new(
+            hook["secret"].encode("utf-8"),
+            msg=json_data.encode("utf-8"),
+            digestmod=hashlib.sha256,
+        ).hexdigest()
+
+        response = requests.post(
+            hook["url"],
+            json=data,
+            headers={"Authorization": "SIG-HMAC-SHA256 {:s}".format(signature)},
+            verify=hook.get("verify", True),
+        )
+
+        if response.status_code != requests.codes.ok:
+            logger.error(
+                "Call to course hook failed for {:s}".format(course_id),
+                extra={"sent": data, "response": response.content},
+            )

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 5.6.0
+version = 5.7.0
 description = FUN MOOC applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION
## Purpose

The courses in our LMS are indexed on a number of external catalogs that must be kept up to date. This can be done by emitting calls to external web hooks.

## Proposal

Use the existing asynchronous task called when a course is published to make calls to external web hooks declared via a new `COURSE_HOOKS" setting.
