### PR TITLE
Fix resource link in course run synchronization to point to lms and release fix 5.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `resource_link` in course run synchronization to point to LMS
+
 ## [5.7.1] - 2021-01-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.2] - 2021-01-18
+
 ### Fixed
 
 - Fix `resource_link` in course run synchronization to point to LMS
@@ -93,7 +95,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rewrite constants related to fun's PDF certificates urls
 
-[unreleased]: https://github.com/openfun/fun-apps/compare/v5.7.1...HEAD
+[unreleased]: https://github.com/openfun/fun-apps/compare/v5.7.2...HEAD
+[5.7.2]: https://github.com/openfun/fun-apps/compare/v5.7.1...v5.7.2
 [5.7.1]: https://github.com/openfun/fun-apps/compare/v5.7.0...v5.7.1
 [5.7.0]: https://github.com/openfun/fun-apps/compare/v5.6.0...v5.7.0
 [5.6.0]: https://github.com/openfun/fun-apps/compare/v5.5.1...v5.6.0

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -35,9 +35,9 @@ def update_courses_meta_data(*args, **kwargs):
     course_id = kwargs["course_id"]
     course_key = CourseKey.from_string(course_id)
     course = modulestore().get_course(course_key)
-    edxapp_domain = microsite.get_value("site_domain", settings.SITE_NAME)
+    edxapp_domain = microsite.get_value("site_domain", settings.LMS_BASE)
     data = {
-        "resource_link": "https://{:s}/courses/{:s}/info/".format(
+        "resource_link": "https://{:s}/courses/{:s}/info".format(
             edxapp_domain, course_id
         ),
         "start": course.start and course.start.isoformat(),

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 5.7.1
+version = 5.7.2
 description = FUN MOOC applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION
### Fixed

- Fix `resource_link` in course run synchronization to point to LMS