### PR TITLE
Improvement/add course language to course run synchronization hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Changed
+
 - Enrich course run synchronization hook with course language
+
+### Fixed
+
+- Pin rsa dependency to 4.3
 
 ## [5.7.2] - 2021-01-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.3] - 2021-02-23
 
 ### Changed
 
@@ -104,7 +105,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rewrite constants related to fun's PDF certificates urls
 
-[unreleased]: https://github.com/openfun/fun-apps/compare/v5.7.2...HEAD
+[unreleased]: https://github.com/openfun/fun-apps/compare/v5.7.3...HEAD
+[5.7.3]: https://github.com/openfun/fun-apps/compare/v5.7.2...v5.7.3
 [5.7.2]: https://github.com/openfun/fun-apps/compare/v5.7.1...v5.7.2
 [5.7.1]: https://github.com/openfun/fun-apps/compare/v5.7.0...v5.7.1
 [5.7.0]: https://github.com/openfun/fun-apps/compare/v5.6.0...v5.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Enrich course run synchronization hook with course language
+
 ## [5.7.2] - 2021-01-18
 
 ### Fixed

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -42,9 +42,10 @@ def update_courses_meta_data(*args, **kwargs):
         ),
         "start": course.start and course.start.isoformat(),
         "end": course.end and course.end.isoformat(),
-        "enrollment_start": course.enrollment_start and course.enrollment_start.isoformat(),
+        "enrollment_start": course.enrollment_start
+        and course.enrollment_start.isoformat(),
         "enrollment_end": course.enrollment_end and course.enrollment_end.isoformat(),
-        "languages": ["fr"],
+        "languages": [course.language or "fr"],
     }
     json_data = json.dumps(data)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     google-api-python-client==1.5.1
     hashids==1.1.0
     pycaption==0.4.6
+    rsa==4.3
     unicodecsv==0.9.4
 packages = find:
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 5.7.2
+version = 5.7.3
 description = FUN MOOC applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION
# Proposal
Course run synchronization hook always send french as course language.
As in studio, editor can set a language to a course run, it is better to enrich the course run synchronization hook with this information.

# Purpose

- [x] Pass course language to course run synchronization hook