### PR TITLE
Feat/prepare fun apps to new fun mooc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Redirect selected routes to the related Richie CMS View
+- Delegate course search to Richie
 
 ## [5.8.0] - 2021-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Redirect selected routes to the related Richie CMS View
+
 ## [5.8.0] - 2021-02-23
 
 ### Added

--- a/funsite/static/funsite/css/header.css
+++ b/funsite/static/funsite/css/header.css
@@ -241,7 +241,6 @@ a.no-decoration:visited {
 
 /* global course search */
 .search-site-block {
-    padding-top: 10px;
     padding-right: 20px;
     background-color: white;
     margin-right: -5px;

--- a/funsite/templates/funsite/parts/footer.html
+++ b/funsite/templates/funsite/parts/footer.html
@@ -5,7 +5,6 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 %>
 <%namespace name='static' file='/static_content.html'/>
-
 <%page args="base_application"/>
 <div class="fun-footer">
     <div class="${'funsite-footer-width' if base_application=='funsite' else 'courseware-width'}">
@@ -13,7 +12,7 @@ from django.utils.translation import ugettext as _
         <ul class="top-footer">
             <div class="left-md-footer">
                 <li>
-                    <a href="${reverse('about')}">
+                    <a href="${settings.PLATFORM_RICHIE_URL}/${LANGUAGE_CODE}/a-propos">
                         ${_("About...")}
                     </a>
                 </li>
@@ -23,23 +22,23 @@ from django.utils.translation import ugettext as _
                     </a>
                 </li>
                 <li>
-                    <a href="${reverse('tos')}">
+                    <a href="${settings.PLATFORM_RICHIE_URL}/${LANGUAGE_CODE}/cgu">
                         ${_("Terms of use")}
                     </a>
                 </li>
             </div><div class="right-md-footer">
                 <li>
-                    <a href="${reverse('honor')}">
+                    <a href="${settings.PLATFORM_RICHIE_URL}/${LANGUAGE_CODE}/charte-utilisateurs">
                         ${_("Usage policy")}
                     </a>
                 </li>
                 <li>
-                    <a href="${reverse('privacy')}">
+                    <a href="${settings.PLATFORM_RICHIE_URL}/${LANGUAGE_CODE}/politique-de-confidentialite">
                         ${_("Privacy policy")}
                     </a>
                 </li>
                 <li>
-                    <a href="${reverse('legal')}">
+                    <a href="${settings.PLATFORM_RICHIE_URL}/${LANGUAGE_CODE}/mentions-legales">
                         ${_("Terms and conditions")}
                     </a>
                 </li>

--- a/funsite/templates/funsite/parts/menu.html
+++ b/funsite/templates/funsite/parts/menu.html
@@ -42,7 +42,7 @@ from django.utils.translation import ugettext as _
     </div>
     <div class="right-header clickable">
         <div class="header-block search-site-block">
-            <input id="search-site" name="query" value="" placeholder="${ _(u'Search courses') }" autocomplete="off">
+            <a href="${reverse('cours')}">${ _(u'Search courses') }</a>
         </div>
         % if not request.user.is_authenticated():
             <a class="signup-link header-block" href="${reverse('register_user')}">

--- a/funsite/urls.py
+++ b/funsite/urls.py
@@ -2,13 +2,45 @@
 
 from django.conf.urls import patterns, url
 from django.views.generic import TemplateView, RedirectView
+from django.conf import settings
+from django.utils import translation
 
 from .views import index
 
-static_pages = ("about", "register_info")
-legal_pages = ("honor", "legal", "privacy", "tos", "charte")
+static_pages = ("register_info",)
+legal_pages = ("charte",)
 
-urls = (url(r"^$", index, name="root"),)
+richie_url = getattr(settings, "PLATFORM_RICHIE_URL", "")
+current_language = translation.get_language()
+
+cms_pages = {
+    "about": "{base_url:s}/{lang:s}/a-propos".format(
+        base_url=richie_url, lang=current_language
+    ),
+    "cours": "{base_url:s}/{lang:s}/cours".format(
+        base_url=richie_url, lang=current_language
+    ),
+    "honor": "{base_url:s}/{lang:s}/charte-utilisateurs".format(
+        base_url=richie_url, lang=current_language
+    ),
+    "legal": "{base_url:s}/{lang:s}/mentions-legales".format(
+        base_url=richie_url, lang=current_language
+    ),
+    "privacy": "{base_url:s}/{lang:s}/politique-de-confidentialite".format(
+        base_url=richie_url, lang=current_language
+    ),
+    "tos": "{base_url:s}/{lang:s}/cgu".format(
+        base_url=richie_url, lang=current_language
+    ),
+    "news": "{base_url:s}/{lang:s}/actualites".format(
+        base_url=richie_url, lang=current_language
+    ),
+    "universities": "{base_url:s}/{lang:s}/etablissements".format(
+        base_url=richie_url, lang=current_language
+    ),
+}
+
+urls = (url(r"^$", RedirectView.as_view(url=richie_url, permanent=True), name="root"),)
 
 urls += tuple(
     url(
@@ -27,6 +59,17 @@ urls += tuple(
             name=name,
         )
         for name in legal_pages
+    ]
+)
+
+urls += tuple(
+    [
+        url(
+            r"^{}/?$".format(name),
+            RedirectView.as_view(url=uri, permanent=True),
+            name=name,
+        )
+        for name, uri in cms_pages.items()
     ]
 )
 


### PR DESCRIPTION
## Purpose
In order to release the new FUN Mooc website, we have to redirect some OpenEdX views to their related Richie views.

## Proposal
- [x] Redirect root, legals, organizations, course and news views to their corresponding Richie views
- [x] Replace search input by a link which redirect to Richie course catalog