### PR TITLE
🔖(minor) bump version to 5.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.9.0] - 2021-04-12
+
+### Added
+
 - Redirect selected routes to the related Richie CMS View
+
+### Changed
+
 - Delegate course search to Richie
 
 ## [5.8.0] - 2021-02-23
@@ -114,7 +121,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rewrite constants related to fun's PDF certificates urls
 
-[unreleased]: https://github.com/openfun/fun-apps/compare/v5.8.0...HEAD
+[unreleased]: https://github.com/openfun/fun-apps/compare/v5.9.0...HEAD
+[5.9.0]: https://github.com/openfun/fun-apps/compare/v5.8.0...v5.9.0
 [5.8.0]: https://github.com/openfun/fun-apps/compare/v5.7.3...v5.8.0
 [5.7.3]: https://github.com/openfun/fun-apps/compare/v5.7.2...v5.7.3
 [5.7.2]: https://github.com/openfun/fun-apps/compare/v5.7.1...v5.7.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 5.8.0
+version = 5.9.0
 description = FUN MOOC applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION
Bump fun-apps to version 5.9.0.

### Added
- Redirect selected routes to the related Richie CMS View

### Changed
- Delegate course search to Richie