### PR TITLE
🔥(courses) remove Elasticsearch synchronization on publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Stop synchronizing Elasticsearch on each publish
+
 ## [5.9.0] - 2021-04-12
 
 ### Added

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -20,13 +20,10 @@ logger = logging.getLogger(__name__)
 def update_courses_meta_data(*args, **kwargs):
     """
     A task to call when a course is updated in OpenEdX.
-    It calls:
-    - the "update_courses" management command to update the "fun-apps" search index.
-    - each course run hook url defined in the `COURSE_HOOKS` setting with scheduling information
-    """
-    # Update fun-apps course catalog
-    call_command("update_courses", *args, **kwargs)
 
+    It calls each course run hook url defined in the `COURSE_HOOKS` setting with
+    scheduling information.
+    """
     hooks = getattr(settings, "COURSE_HOOKS", [])
     if not hooks:
         return


### PR DESCRIPTION
## Purpose

The catalog app is not used anymore in production and we don't want to synchronize Elasticsearch on each publish like it used to be.

## Proposal

Remove call to `update_courses` command from method that is called on `post_publish` signal.