### PR TITLE
🐛(payment) fix absolute url in payment email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix hardcoded absolute url in payment email
+
 ## [5.10.1] - 2021-07-07
 
 ### Fixed

--- a/payment/templates/payment/email/base.html
+++ b/payment/templates/payment/email/base.html
@@ -42,7 +42,7 @@ from django.utils.translation import ugettext as _
         <table border="0" width="100%" cellpadding="0" cellspacing="0">
           <tr>
             <td valign="middle" style="padding:10px 0; text-align:left;" width="150">
-              <a href="https://www.fun-mooc.fr"><img style="margin-left: 8px;" src="https://www.fun-mooc.fr/static/bulk_email/images/logo-funmooc.png" alt="alt text" width="80" height="80" border="0" align="left"></a>
+              <a href="https://www.fun-mooc.fr"><img style="margin-left: 8px;" src="${'https://{lms_base}/static/bulk_email/images/logo-funmooc.png'.format(lms_base=settings.LMS_BASE)}" alt="alt text" width="80" height="80" border="0" align="left"></a>
             </td>
             <td valign="middle" style="padding:10px 0; text-align:right; line-height:1.1; font-family: sans-serif; font-size: 13px; color: #1f87c7;">
               <h1 style="font-size: 22px; margin-right: 8px;">Se former en liberté sur la plateforme FUN</h1>
@@ -81,8 +81,8 @@ from django.utils.translation import ugettext as _
         ${_(u"This is was automatically generated email, please do not reply.")}
         <br><br>
 
-        <a href="${'https://twitter.com/{account}'.format(account=settings.PLATFORM_TWITTER_ACCOUNT)}" alt="${_(u"FUN&#39;s Twitter account")}"><img src="https://www.fun-mooc.fr/static/bulk_email/images/twitter.png"></a>&nbsp;&nbsp;&nbsp;
-        <a href="${settings.PLATFORM_FACEBOOK_ACCOUNT}" alt="${_(u"FUN&#39;s Facebook account")}"><img src="https://www.fun-mooc.fr/static/bulk_email/images/facebook.png"></a>
+        <a href="${'https://twitter.com/{account}'.format(account=settings.PLATFORM_TWITTER_ACCOUNT)}" alt="${_(u"FUN&#39;s Twitter account")}"><img src="${'https://{lms_base}/static/bulk_email/images/twitter.png'.format(lms_base=settings.LMS_BASE)}"></a>&nbsp;&nbsp;&nbsp;
+        <a href="${settings.PLATFORM_FACEBOOK_ACCOUNT}" alt="${_(u"FUN&#39;s Facebook account")}"><img src="${'https://{lms_base}/static/bulk_email/images/facebook.png'.format(lms_base=settings.LMS_BASE)}"></a>
 
       </td>
     </tr>


### PR DESCRIPTION
### Purpose

An absolute url was hardcoded so a link in the payment confirmation email was broken since we have moved openedx to "lms.fun-mooc.fr".

### Proposal

Compute the absolute url with the `LMS_BASE` setting.