### PR TITLE
✨(videoproviders) try loading VideoFront videos from metadata file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Protect ourselves against VideoFront downtimes by trying to load the video
+  object directly from S3 before falling back to querying the VideoFront API
+
 ## [2.4.2+wb] - 2020-07-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Protect ourselves against VideoFront downtimes by trying to load the video
   object directly from S3 before falling back to querying the VideoFront API
 
+### Fixed
+
+- Pin rsa dependency to 4.5
+
 ## [2.4.2+wb] - 2020-07-20
 
 ### Changed

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     google-api-python-client==1.5.1
     hashids==1.1.0
     pycaption==0.4.6
+    rsa==4.5
     unicodecsv==0.9.4
 packages = find:
 zip_safe = False


### PR DESCRIPTION
## Purpose

We want to protect against VideoFront server downtimes (including very long ones :stuck_out_tongue:). 

## Proposal

A ready-made VideoFront video document was added as a metadata json file in the S3 bucket alongside each video (example: https://d381hmu4snvm3e.cloudfront.net/videos/0UMvtYaQrrxr/metadata.json). 

We first try getting the video document from this metadata json file, and fall back to the previous behavior: requesting it to the VideoFront API.
