### PR TITLE
Release 2.5.0+wb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0+wb] - 2021-08-17
+
 ### Changed
 
 - Protect ourselves against VideoFront downtimes by trying to load the video
@@ -62,7 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `selftest` application
 
-[unreleased]: https://github.com/openfun/fun-apps/compare/v2.4.2+wb...eucalyptus.3-wb
+[unreleased]: https://github.com/openfun/fun-apps/compare/v2.5.0+wb...eucalyptus.3-wb
+[2.5.0+wb]: https://github.com/openfun/fun-apps/compare/v2.4.2+wb...v2.5.0+wb
 [2.4.2+wb]: https://github.com/openfun/fun-apps/compare/v2.4.1+wb...v2.4.2+wb
 [2.4.1+wb]: https://github.com/openfun/fun-apps/compare/v2.4.0+wb...v2.4.1+wb
 [2.4.0+wb]: https://github.com/openfun/fun-apps/compare/v2.3.1+wb...v2.4.0+wb

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 2.4.2+wb
+version = 2.5.0+wb
 description = FUN-MOOC White Brands applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION

### Changed

- Protect ourselves against VideoFront downtimes by trying to load the video
  object directly from S3 before falling back to querying the VideoFront API

### Fixed

- Pin rsa dependency to 4.5
