### PR TITLE
✨(courses) add course synchronization on enrollment count and release 5.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.12.0] - 2022-01-17
+
 ### Added
 
 - Add enrollment count to the course run synchronization hook payload
@@ -148,7 +150,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rewrite constants related to fun's PDF certificates urls
 
-[unreleased]: https://github.com/openfun/fun-apps/compare/v5.11.0...HEAD
+[unreleased]: https://github.com/openfun/fun-apps/compare/v5.12.0...HEAD
+[5.12.0]: https://github.com/openfun/fun-apps/compare/v5.11.0...v5.12.0
 [5.11.0]: https://github.com/openfun/fun-apps/compare/v5.10.1...v5.11.0
 [5.10.1]: https://github.com/openfun/fun-apps/compare/v5.10.0...v5.10.1
 [5.10.0]: https://github.com/openfun/fun-apps/compare/v5.9.0...v5.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add enrollment count to the course run synchronization hook payload
+
 ## [5.11.0] - 2021-08-17
 
 ### Changed

--- a/courses/signals.py
+++ b/courses/signals.py
@@ -1,15 +1,40 @@
 from django.dispatch import receiver
 
+from student.signals import ENROLL_STATUS_CHANGE
+from student.models import EnrollStatusChange
 from xmodule.modulestore.django import SignalHandler
 
 
 @receiver(SignalHandler.course_published, dispatch_uid='fun.courses.signals.update_courses')
 def update_course_meta_data_on_studio_publish(sender, course_key, **kwargs):
+    """Trigger hook when publishing a change to a course"""
     from django.conf import settings
     if getattr(settings, "COURSE_SIGNALS_DISABLED", False):
         return 'FUN courses meta data update has been skipped.'
 
     from .tasks import update_courses_meta_data
-    # course_key is a CourseKey object and course_id its sting representation
+    # course_key is a CourseKey object and course_id its string representation
     update_courses_meta_data.delay(course_id=unicode(course_key))
-    return 'FUN courses meta data update has been triggered.'
+    return 'FUN courses meta data update has been triggered from course publish.'
+
+
+@receiver(
+    ENROLL_STATUS_CHANGE,
+    dispatch_uid='fun.courses.signals.change_enrollment_status')
+def sync_openedx_to_richie_after_enrollment_status_change(
+        sender, event=None, course_id=None, **kwargs
+    ):
+    """
+    Trigger hook when changing a course enrollment and the change if of the type "enroll
+    """
+
+    if event != EnrollStatusChange.enroll:
+        return (
+            'FUN courses meta data update has been skipped, '
+            'because the event status change is not about enroll'
+        )
+
+    from .tasks import update_courses_meta_data
+    # course_key is a CourseKey object and course_id its string representation
+    update_courses_meta_data.delay(course_id=unicode(course_id))
+    return 'FUN courses meta data update has been triggered from enrollment status change.'

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -7,10 +7,11 @@ import logging
 from django.conf import settings
 from django.core.management import call_command
 
+import requests
 from celery import shared_task
 from microsite_configuration import microsite
 from opaque_keys.edx.keys import CourseKey
-import requests
+from student.models import CourseEnrollment
 from xmodule.modulestore.django import modulestore
 
 logger = logging.getLogger(__name__)
@@ -43,6 +44,7 @@ def update_courses_meta_data(*args, **kwargs):
         and course.enrollment_start.isoformat(),
         "enrollment_end": course.enrollment_end and course.enrollment_end.isoformat(),
         "languages": [course.language or "fr"],
+        "enrollment_count" : CourseEnrollment.objects.filter(course_id=course_id).count()
     }
     json_data = json.dumps(data)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 5.11.0
+version = 5.12.0
 description = FUN MOOC applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION
## Purpose

We have recently introduced enrollment counts in [Richie](https://github.com/openfun/richie). As a result, we now need to update the count each time an enrollment is made.

## Proposal

- [x] Add "enrollment_count" to the payload sent to the synchronization hook
- [x] Add a signal to update the course run info each time an enrollment is modified

## 🔖 Release version to 5.12.0

### Added
    
- Add enrollment count to the course run synchronization hook payload
