### PR TITLE
Eucalyptus add course runs synchronization hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.0+wb] - 2022-01-21
+
 ### Added
 
 - Allow synchronizing course runs via an external synchronization hook
@@ -68,7 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `selftest` application
 
-[unreleased]: https://github.com/openfun/fun-apps/compare/v2.5.0+wb...eucalyptus.3-wb
+[unreleased]: https://github.com/openfun/fun-apps/compare/v2.6.0+wb...eucalyptus.3-wb
+[2.6.0+wb]: https://github.com/openfun/fun-apps/compare/v2.5.0+wb...v2.6.0+wb
 [2.5.0+wb]: https://github.com/openfun/fun-apps/compare/v2.4.2+wb...v2.5.0+wb
 [2.4.2+wb]: https://github.com/openfun/fun-apps/compare/v2.4.1+wb...v2.4.2+wb
 [2.4.1+wb]: https://github.com/openfun/fun-apps/compare/v2.4.0+wb...v2.4.1+wb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow synchronizing course runs via an external synchronization hook
+
 ## [2.5.0+wb] - 2021-08-17
 
 ### Changed

--- a/courses/signals.py
+++ b/courses/signals.py
@@ -1,15 +1,30 @@
+from django.db.models.signals import post_save
 from django.dispatch import receiver
 
+from student.models import CourseEnrollment
 from xmodule.modulestore.django import SignalHandler
 
 
 @receiver(SignalHandler.course_published, dispatch_uid='fun.courses.signals.update_courses')
 def update_course_meta_data_on_studio_publish(sender, course_key, **kwargs):
+    """Trigger hook when publishing a change to a course"""
     from django.conf import settings
     if getattr(settings, "COURSE_SIGNALS_DISABLED", False):
         return 'FUN courses meta data update has been skipped.'
 
     from .tasks import update_courses_meta_data
-    # course_key is a CourseKey object and course_id its sting representation
+    # course_key is a CourseKey object and course_id its string representation
     update_courses_meta_data.delay(course_id=unicode(course_key))
-    return 'FUN courses meta data update has been triggered.'
+    return 'FUN courses meta data update has been triggered from course publish.'
+
+
+@receiver(
+    post_save,
+    sender=CourseEnrollment,
+    dispatch_uid='fun.courses.signals.sync_to_richie')
+def sync_openedx_to_richie_post_enrollment_save(sender, instance, **kwargs):
+    """Trigger hook when changing a course enrollment."""
+    from .tasks import update_courses_meta_data
+    # course_key is a CourseKey object and course_id its string representation
+    update_courses_meta_data.delay(course_id=unicode(instance.course_id))
+    return 'FUN courses meta data update has been triggered from enrollment status change.'

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -1,15 +1,69 @@
 # -*- coding: utf-8 -*-
+import hashlib
+import hmac
+import json
+import logging
 
+from django.conf import settings
+
+import requests
 from celery import shared_task
+from microsite_configuration import microsite
+from opaque_keys.edx.keys import CourseKey
+from student.models import CourseEnrollment
+from xmodule.modulestore.django import modulestore
 
-from django.core.management import call_command
+logger = logging.getLogger(__name__)
 
 
 @shared_task
 def update_courses_meta_data(*args, **kwargs):
-    '''
-    A task that serves as proxy to the management command.
-    Can be used for instance when a signal is fired to update
-    a single course or to run periodic tasks.
-    '''
-    call_command('update_courses', *args, **kwargs)
+    """
+    A task to call when a course is updated in OpenEdX.
+
+    It calls each course run hook url defined in the `COURSE_HOOKS` setting with
+    scheduling information.
+    """
+    hooks = getattr(settings, "COURSE_HOOKS", [])
+    if not hooks:
+        return
+
+    # Synchronize with external course hook
+    course_id = kwargs["course_id"]
+    course_key = CourseKey.from_string(course_id)
+    course = modulestore().get_course(course_key)
+    edxapp_domain = microsite.get_value("site_domain", settings.LMS_BASE)
+
+    data = {
+        "resource_link": "https://{:s}/courses/{:s}/info".format(
+            edxapp_domain, course_id
+        ),
+        "start": course.start and course.start.isoformat(),
+        "end": course.end and course.end.isoformat(),
+        "enrollment_start": course.enrollment_start
+        and course.enrollment_start.isoformat(),
+        "enrollment_end": course.enrollment_end and course.enrollment_end.isoformat(),
+        "languages": [course.language or "fr"],
+        "enrollment_count" : CourseEnrollment.objects.filter(course_id=course_key).count()
+    }
+    json_data = json.dumps(data)
+
+    for hook in hooks:
+        signature = hmac.new(
+            hook["secret"].encode("utf-8"),
+            msg=json_data.encode("utf-8"),
+            digestmod=hashlib.sha256,
+        ).hexdigest()
+
+        response = requests.post(
+            hook["url"],
+            json=data,
+            headers={"Authorization": "SIG-HMAC-SHA256 {:s}".format(signature)},
+            verify=hook.get("verify", True),
+        )
+
+        if response.status_code != requests.codes.ok:
+            logger.error(
+                "Call to course hook failed for {:s}".format(course_id),
+                extra={"sent": data, "response": response.content},
+            )

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 2.5.0+wb
+version = 2.6.0+wb
 description = FUN-MOOC White Brands applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION
## Purpose

We want to add course run synchronization with an external catalogue like [richie](https://richie.documentation) for the `eucalyptus.3-wb` image. 

## Proposal

Port web hook trigger from the `dogwood.3-fun` branch.

### 🔖 2.6.0+wb

#### Added

- Allow synchronizing course runs via an external synchronization hook
