### PR TITLE
[dogwood]🐛(courses) fix course run synchronization on enrollment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix course run synchronization when triggered on enrollment
+
 ## [5.12.0] - 2022-01-17
 
 ### Added

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -5,7 +5,6 @@ import json
 import logging
 
 from django.conf import settings
-from django.core.management import call_command
 
 import requests
 from celery import shared_task
@@ -34,6 +33,7 @@ def update_courses_meta_data(*args, **kwargs):
     course_key = CourseKey.from_string(course_id)
     course = modulestore().get_course(course_key)
     edxapp_domain = microsite.get_value("site_domain", settings.LMS_BASE)
+
     data = {
         "resource_link": "https://{:s}/courses/{:s}/info".format(
             edxapp_domain, course_id
@@ -44,7 +44,7 @@ def update_courses_meta_data(*args, **kwargs):
         and course.enrollment_start.isoformat(),
         "enrollment_end": course.enrollment_end and course.enrollment_end.isoformat(),
         "languages": [course.language or "fr"],
-        "enrollment_count" : CourseEnrollment.objects.filter(course_id=course_id).count()
+        "enrollment_count" : CourseEnrollment.objects.filter(course_id=course_key).count()
     }
     json_data = json.dumps(data)
 


### PR DESCRIPTION
## Purpose

The enrollment signal used to update course run counts was copied from what @igobranco did in Lilac but this signal does not work properly in dogwood. 

## Proposal

We can you the "post_save" signal without being overwhelmed.