### PR TITLE
Patch/fun apps 5.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.15.1] - 2023-07-07
+
 ### Fixed
 
 - Update Manifest.in to include mailing_list html, po and mo files
@@ -183,7 +185,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rewrite constants related to fun's PDF certificates urls
 
-[unreleased]: https://github.com/openfun/fun-apps/compare/v5.15.0...HEAD
+[unreleased]: https://github.com/openfun/fun-apps/compare/v5.15.1...HEAD
+[5.15.1]: https://github.com/openfun/fun-apps/compare/v5.15.0...v5.15.1
 [5.15.0]: https://github.com/openfun/fun-apps/compare/v5.14.0...v5.15.0
 [5.14.0]: https://github.com/openfun/fun-apps/compare/v5.13.1...v5.14.0
 [5.13.1]: https://github.com/openfun/fun-apps/compare/v5.13.0...v5.13.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update Manifest.in to include mailing_list html, po and mo files
+
 ## [5.15.0] - 2023-07-07
 
 ### Added

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,10 +6,11 @@ recursive-include contact *.html *.mo *.po
 recursive-include course_dashboard *.css *.eot *.gif *.html *.js *.mo *.png *.po *.svg *.ttf *.woff
 recursive-include course_pages *.html *.mo *.po *.underscore
 recursive-include courses *.css *.mo *.po *.txt
+recursive-include fun *.cfg *.css *.eot *.gif *.html *.ico *.js *.less *.map *.mo *.png *.po *.svg *.swf *.ttf *.underscore *.vtt *.woff
 recursive-include fun_api *.mo *.po
 recursive-include fun_certificates *.html *.jpg *.mo *.png *.po *.ttf
-recursive-include fun *.cfg *.css *.eot *.gif *.html *.ico *.js *.less *.map *.mo *.png *.po *.svg *.swf *.ttf *.underscore *.vtt *.woff
 recursive-include funsite *.css *.eot *.html *.jpg *.js *.json *.map *.md *.mo *.nuspec *.png *.po *.svg *.ttf *.txt *.underscore *.woff *.woff2 *.xml
+recursive-include mailing_list *.html *.mo *.po
 recursive-include newsfeed *.html *.mo *.po
 recursive-include payment *.css *.html *.mo *.po *.txt
 recursive-include universities *.html *.mo *.po

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 5.15.0
+version = 5.15.1
 description = FUN MOOC applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION
## Purpose

The html templates were not copied to the package published on pypi.

Update Manifest.in then release patch version 5.15.1

### Fixed

- Update Manifest.in to include mailing_list html, po and mo files



