### PR TITLE
Add title to course run synchronization data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add title to course run synchronization data
+
 ## [5.15.1] - 2023-07-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.16.0] - 2023-10-10
+
 ### Added
 
 - Add title to course run synchronization data
@@ -189,7 +191,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rewrite constants related to fun's PDF certificates urls
 
-[unreleased]: https://github.com/openfun/fun-apps/compare/v5.15.1...HEAD
+[unreleased]: https://github.com/openfun/fun-apps/compare/v5.16.0...HEAD
+[5.16.0]: https://github.com/openfun/fun-apps/compare/v5.15.1...v5.16.0
 [5.15.1]: https://github.com/openfun/fun-apps/compare/v5.15.0...v5.15.1
 [5.15.0]: https://github.com/openfun/fun-apps/compare/v5.14.0...v5.15.0
 [5.14.0]: https://github.com/openfun/fun-apps/compare/v5.13.1...v5.14.0

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -38,6 +38,7 @@ def update_courses_meta_data(*args, **kwargs):
         "resource_link": "https://{:s}/courses/{:s}/info".format(
             edxapp_domain, course_id
         ),
+        "title": unicode(course.display_name_with_default).encode('utf-8'),
         "start": course.start and course.start.isoformat(),
         "end": course.end and course.end.isoformat(),
         "enrollment_start": course.enrollment_start

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 5.15.1
+version = 5.16.0
 description = FUN MOOC applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION
## Purpose

When the course code of a course run (in the course key) is not known by the remote site, we want to be able to automatically create it. For this, it would be nice to set a title for the course we will create. In MongoDB there is a "display_name" field with this info.

### 🔖 Added

- Add title to course run synchronization data