### PR TITLE
🐛(register) redirect to richie root after registering

### DIFF
--- a/funsite/templates/lms/register.html
+++ b/funsite/templates/lms/register.html
@@ -24,8 +24,15 @@ from student.models import UserProfile
          });
 
          function onSuccess(json) {
-             var url = json.redirect_url || "${reverse('dashboard')}";
-             location.href = url;
+            var queryParameters = new URLSearchParams(location.search);
+            var next = queryParameters.get('next');
+            if (next) {
+              queryParameters.delete('next');
+              location.href = location.origin + '/' + next + '?' + queryParameters.toString();
+            } else {
+              var url = json.redirect_url || "${reverse('dashboard')}";
+              location.href = url;
+            }
          }
 
          function onError(jqXHR) {


### PR DESCRIPTION
After registering, a redirect to the lms dashboard was called in js, overriding current next query parameter value.
It was catched by edx, and redirected to payment/terms, adding dashboard as next query parameters.