### PR TITLE
🔍️(backend) prevent cert pages indexation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Prevent to index certificate pages
+
 ## [5.20.0] - 2024-05-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.21.0] - 2025-01-13
+
 ### Changed
 
 - Prevent to index certificate pages
@@ -219,8 +221,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rewrite constants related to fun's PDF certificates urls
 
-[unreleased]: https://github.com/openfun/fun-apps/compare/v5.19.0...HEAD
-[5.20.0]: https://github.com/openfun/fun-apps/compare/v5.18.0...v5.20.0
+[unreleased]: https://github.com/openfun/fun-apps/compare/v5.21.0...HEAD
+[5.21.0]: https://github.com/openfun/fun-apps/compare/v5.20.0...v5.21.0
+[5.20.0]: https://github.com/openfun/fun-apps/compare/v5.19.0...v5.20.0
 [5.19.0]: https://github.com/openfun/fun-apps/compare/v5.18.0...v5.19.0
 [5.18.0]: https://github.com/openfun/fun-apps/compare/v5.17.0...v5.18.0
 [5.17.0]: https://github.com/openfun/fun-apps/compare/v5.16.0...v5.17.0

--- a/fun_certificates/templates/certificates/accomplishment-base.html
+++ b/fun_certificates/templates/certificates/accomplishment-base.html
@@ -15,6 +15,7 @@ course_mode_class = course_mode if course_mode else ''
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex">
 
     <title>${document_title}</title>
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 5.20.0
+version = 5.21.0
 description = FUN MOOC applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION
Currently, certificate pages are indexed, we don't want that so we had a meta tag to explicit ask crawler to ignore those pages.

Release version 5.21.0
