### PR TITLE
Dogwood.3 fun keycloak

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   build:
 
     docker:
-      - image:  cimg/python:2.7-stretch
+      - image:  cimg/python:2.7.16
 
     steps:
       - checkout
@@ -63,7 +63,7 @@ jobs:
   validate:
 
     docker:
-      - image:  cimg/python:2.7-stretch
+      - image:  cimg/python:2.7.16
         environment:
           # This is the branch that is supposed to contain target commit/tag
           TARGET_BRANCH: dogwood.3-fun

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   build:
 
     docker:
-      - image: circleci/python:2.7-stretch
+      - image:  cimg/python:2.7-stretch
 
     steps:
       - checkout
@@ -63,7 +63,7 @@ jobs:
   validate:
 
     docker:
-      - image: circleci/python:2.7-stretch
+      - image:  cimg/python:2.7-stretch
         environment:
           # This is the branch that is supposed to contain target commit/tag
           TARGET_BRANCH: dogwood.3-fun

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.22.0] - 2026-01-28
+
+- Update overlay - funsite 
+
 ## [5.21.0] - 2025-01-13
 
 ### Changed

--- a/funsite/static/funsite/js/fun.js
+++ b/funsite/static/funsite/js/fun.js
@@ -12,17 +12,20 @@
      *   must redirect directly to /keycloak-login (SSO), without opening the overlay.
      * - on other pages (FUN / marketing site), we keep the existing overlay behaviour.
      */
-    $('#top-menu .right-header .login-link').on('click', function(event) {
+    // Use event delegation to ensure the event is attached even if the element doesn't exist yet
+    $(document).on('click', '#top-menu .right-header .login-link', function(event) {
         var path = window.location.pathname || '';
-
-        // Cas spécifique : page de login LMS
+        console.log('path', path);
+        // Specific case: LMS login page
         if (path.indexOf('/login') === 0) {
             event.preventDefault();
+            event.stopImmediatePropagation(); // Prevent other handlers from executing
+            event.stopPropagation();
             window.location.href = '/keycloak-login';
             return false;
         }
 
-        // Comportement historique : ouverture/fermeture de l'overlay
+        // Historical behavior: open/close overlay
         $('#login-overlay').toggle();
         if ($('#login-overlay').is(':visible')) {
             $('#login-overlay input[name=\"email\"]').focus();

--- a/funsite/static/funsite/js/fun.js
+++ b/funsite/static/funsite/js/fun.js
@@ -5,11 +5,27 @@
     var page = window.location.pathname.split('/')[1];
     $('#sandwich-overlay [data-location="'+ page +'"]').addClass('selected');
 
-    /* Login overlay */
+    /* Login overlay / Keycloak
+     *
+     * Expected behaviour:
+     * - on the LMS login page (/login...), the red "Connexion" button
+     *   must redirect directly to /keycloak-login (SSO), without opening the overlay.
+     * - on other pages (FUN / marketing site), we keep the existing overlay behaviour.
+     */
     $('#top-menu .right-header .login-link').on('click', function(event) {
+        var path = window.location.pathname || '';
+
+        // Cas spécifique : page de login LMS
+        if (path.indexOf('/login') === 0) {
+            event.preventDefault();
+            window.location.href = '/keycloak-login';
+            return false;
+        }
+
+        // Comportement historique : ouverture/fermeture de l'overlay
         $('#login-overlay').toggle();
         if ($('#login-overlay').is(':visible')) {
-            $('#login-overlay input[name="email"]').focus();
+            $('#login-overlay input[name=\"email\"]').focus();
         }
     });
 

--- a/funsite/static/funsite/js/fun.js
+++ b/funsite/static/funsite/js/fun.js
@@ -15,8 +15,11 @@
     // Use event delegation to ensure the event is attached even if the element doesn't exist yet
     $(document).on('click', '#top-menu .right-header .login-link', function(event) {
         var path = window.location.pathname || '';
-        console.log('path', path);
-        // Specific case: LMS login page
+        var href = $(this).attr('href') || '';
+        var host = window.location.hostname || '';
+
+        // 1) LMS login pages: /login and /login?next=/account/settings
+        //    → redirect current tab to /keycloak-login (SSO)
         if (path.indexOf('/login') === 0) {
             event.preventDefault();
             event.stopImmediatePropagation(); // Prevent other handlers from executing
@@ -25,11 +28,38 @@
             return false;
         }
 
-        // Historical behavior: open/close overlay
-        $('#login-overlay').toggle();
-        if ($('#login-overlay').is(':visible')) {
-            $('#login-overlay input[name=\"email\"]').focus();
+        // 2) Other LMS pages (e.g. /courses/...) with a login link pointing to /login
+        //    → open /keycloak-login in a new tab AND refresh the current page
+        //    We restrict this behaviour to LMS hostnames to avoid touching the marketing site.
+        var isLmsHost = (
+            host.indexOf('lms.') === 0 ||                 // lms.preprod-fun.apps.openfun.fr
+            host === 'localhost'                          // local dev (nginx on 8073)
+        );
+        if (isLmsHost && href && href.indexOf('/login') !== -1) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            event.stopPropagation();
+
+            // Open Keycloak login in a new tab
+            window.open('/keycloak-login', '_blank');
+            // Refresh current page to keep it in sync (user will still be anonymous here)
+            window.location.reload();
+            return false;
         }
+
+        // 3) Historical behavior: open/close overlay on the FUN marketing site
+        //    This only applies when href is '#' (overlay trigger).
+        if (href === '#' || !href) {
+            event.preventDefault();
+            $('#login-overlay').toggle();
+            if ($('#login-overlay').is(':visible')) {
+                $('#login-overlay input[name=\"email\"]').focus();
+            }
+            return false;
+        }
+
+        // 4) Fallback: let the browser handle the click normally
+        return true;
     });
 
     function getParameterByName(name) {

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = fun-apps
-version = 5.21.0
+version = 5.22.0
 description = FUN MOOC applications
 long_description = file: README.md
 author = Open FUN (France Universite Numerique)


### PR DESCRIPTION
- On /login pages: redirect to /keycloak-login in current tab (existing behavior)
- On other LMS pages (e.g., /courses/...): open /keycloak-login in new tab and reload current page
- On marketing site (preprod.fun.apps.openfun.fr): keep overlay behavior unchanged
- Prevent unwanted redirects from marketing site to LMS login page